### PR TITLE
More mob groups

### DIFF
--- a/tradingcards-api/src/main/java/net/tinetwork/tradingcards/api/model/MobGroup.java
+++ b/tradingcards-api/src/main/java/net/tinetwork/tradingcards/api/model/MobGroup.java
@@ -1,0 +1,26 @@
+package net.tinetwork.tradingcards.api.model;
+
+import org.bukkit.entity.EntityType;
+
+import java.util.Set;
+
+/**
+ * @author sarhatabaot
+ */
+public class MobGroup {
+    private final String id;
+    private final Set<EntityType> entities;
+
+    public MobGroup(final String id, final Set<EntityType> entities) {
+        this.id = id;
+        this.entities = entities;
+    }
+
+    public Set<EntityType> getEntities() {
+        return entities;
+    }
+
+    public String getId() {
+        return id;
+    }
+}

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/DefaultMobGroups.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/DefaultMobGroups.java
@@ -1,0 +1,45 @@
+package net.tinetwork.tradingcards.tradingcardsplugin;
+
+import net.tinetwork.tradingcards.api.model.MobGroup;
+import org.bukkit.entity.EntityType;
+
+import java.util.Set;
+
+/**
+ * @author sarhatabaot
+ */
+public enum DefaultMobGroups {
+    PASSIVE(new MobGroup("passive", Set.of(EntityType.DONKEY, EntityType.MULE, EntityType.SKELETON_HORSE, EntityType.CHICKEN, EntityType.COW,
+            EntityType.SQUID, EntityType.TURTLE, EntityType.TROPICAL_FISH, EntityType.PUFFERFISH, EntityType.SHEEP, EntityType.PIG,
+            EntityType.PHANTOM, EntityType.SALMON, EntityType.COD, EntityType.RABBIT, EntityType.VILLAGER, EntityType.BAT,
+            EntityType.PARROT, EntityType.HORSE, EntityType.WANDERING_TRADER, EntityType.CAT, EntityType.MUSHROOM_COW, EntityType.TRADER_LLAMA))),
+    NEUTRAL(new MobGroup("neutral", Set.of(EntityType.ENDERMAN, EntityType.POLAR_BEAR, EntityType.LLAMA, EntityType.WOLF,
+            EntityType.DOLPHIN, EntityType.SNOWMAN, EntityType.IRON_GOLEM, EntityType.BEE, EntityType.PANDA, EntityType.FOX))),
+    HOSTILE(new MobGroup("hostile", Set.of(EntityType.SPIDER, EntityType.CAVE_SPIDER, EntityType.ZOMBIE, EntityType.SKELETON, EntityType.CREEPER,
+            EntityType.BLAZE, EntityType.SILVERFISH, EntityType.GHAST, EntityType.SLIME, EntityType.EVOKER, EntityType.VINDICATOR,
+            EntityType.VEX, EntityType.SHULKER, EntityType.GUARDIAN, EntityType.MAGMA_CUBE, EntityType.ELDER_GUARDIAN, EntityType.STRAY,
+            EntityType.HUSK, EntityType.DROWNED, EntityType.WITCH, EntityType.ZOMBIE_VILLAGER, EntityType.ENDERMITE, EntityType.PILLAGER, EntityType.RAVAGER,
+            EntityType.HOGLIN, EntityType.PIGLIN, EntityType.STRIDER, EntityType.ZOGLIN, EntityType.ZOMBIFIED_PIGLIN, EntityType.WITHER_SKELETON))),
+    BOSS(new MobGroup("boss", Set.of(EntityType.ENDER_DRAGON, EntityType.WITHER)));
+    private final MobGroup group;
+
+    DefaultMobGroups(final MobGroup group) {
+        this.group = group;
+    }
+
+    public MobGroup getGroup() {
+        return group;
+    }
+
+    public static boolean isMob(EntityType type) {
+        for(DefaultMobGroups defaultMobGroups: values()) {
+            if(defaultMobGroups.getGroup().getEntities().contains(type))
+                return true;
+        }
+        return false;
+    }
+
+    public boolean hasMobType(EntityType type) {
+        return group.getEntities().contains(type);
+    }
+}

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/TradingCards.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/TradingCards.java
@@ -2,7 +2,6 @@ package net.tinetwork.tradingcards.tradingcardsplugin;
 
 import co.aikar.commands.InvalidCommandArgument;
 import co.aikar.commands.PaperCommandManager;
-import com.google.common.collect.ImmutableSet;
 import net.milkbowl.vault.economy.Economy;
 import net.tinetwork.tradingcards.api.TradingCardsPlugin;
 import net.tinetwork.tradingcards.api.manager.PackManager;
@@ -74,13 +73,6 @@ import java.util.stream.Stream;
 
 public class TradingCards extends TradingCardsPlugin<TradingCard> {
     private final Random random = new Random();
-
-    /* Mobs */
-    private ImmutableSet<EntityType> hostileMobs;
-    private ImmutableSet<EntityType> passiveMobs;
-    private ImmutableSet<EntityType> neutralMobs;
-    private ImmutableSet<EntityType> bossMobs;
-
     /* Configs */
     private Storage<TradingCard> storage;
 
@@ -129,8 +121,6 @@ public class TradingCards extends TradingCardsPlugin<TradingCard> {
     @Override
     public void onEnable() {
         Util.init(getLogger());
-
-        cacheMobs();
         initConfigs();
 
         try {
@@ -378,23 +368,6 @@ public class TradingCards extends TradingCardsPlugin<TradingCard> {
         pm.registerEvents(new DeckListener(this), this);
     }
 
-    private void cacheMobs() {
-        this.hostileMobs = ImmutableSet.<EntityType>builder().add(EntityType.SPIDER, EntityType.CAVE_SPIDER, EntityType.ZOMBIE, EntityType.SKELETON, EntityType.CREEPER,
-                EntityType.BLAZE, EntityType.SILVERFISH, EntityType.GHAST, EntityType.SLIME, EntityType.EVOKER, EntityType.VINDICATOR,
-                EntityType.VEX, EntityType.SHULKER, EntityType.GUARDIAN, EntityType.MAGMA_CUBE, EntityType.ELDER_GUARDIAN, EntityType.STRAY,
-                EntityType.HUSK, EntityType.DROWNED, EntityType.WITCH, EntityType.ZOMBIE_VILLAGER, EntityType.ENDERMITE, EntityType.PILLAGER, EntityType.RAVAGER,
-                EntityType.HOGLIN, EntityType.PIGLIN, EntityType.STRIDER, EntityType.ZOGLIN, EntityType.ZOMBIFIED_PIGLIN, EntityType.WITHER_SKELETON).build();
-
-        this.neutralMobs = ImmutableSet.<EntityType>builder().add(EntityType.ENDERMAN, EntityType.POLAR_BEAR, EntityType.LLAMA, EntityType.WOLF,
-                EntityType.DOLPHIN, EntityType.SNOWMAN, EntityType.IRON_GOLEM, EntityType.BEE, EntityType.PANDA, EntityType.FOX).build();
-
-        this.passiveMobs = ImmutableSet.<EntityType>builder().add(EntityType.DONKEY, EntityType.MULE, EntityType.SKELETON_HORSE, EntityType.CHICKEN, EntityType.COW,
-                EntityType.SQUID, EntityType.TURTLE, EntityType.TROPICAL_FISH, EntityType.PUFFERFISH, EntityType.SHEEP, EntityType.PIG,
-                EntityType.PHANTOM, EntityType.SALMON, EntityType.COD, EntityType.RABBIT, EntityType.VILLAGER, EntityType.BAT,
-                EntityType.PARROT, EntityType.HORSE, EntityType.WANDERING_TRADER, EntityType.CAT, EntityType.MUSHROOM_COW, EntityType.TRADER_LLAMA).build();
-        this.bossMobs = ImmutableSet.<EntityType>builder().add(EntityType.ENDER_DRAGON, EntityType.WITHER).build();
-    }
-
 
     private boolean setupEconomy() {
         if (this.getServer().getPluginManager().getPlugin("Vault") == null) {
@@ -411,19 +384,19 @@ public class TradingCards extends TradingCardsPlugin<TradingCard> {
     }
 
     public boolean isMobHostile(EntityType e) {
-        return this.hostileMobs.contains(e);
+        return DefaultMobGroups.HOSTILE.hasMobType(e);
     }
 
     public boolean isMobNeutral(EntityType e) {
-        return this.neutralMobs.contains(e);
+        return DefaultMobGroups.NEUTRAL.hasMobType(e);
     }
 
     public boolean isMobPassive(EntityType e) {
-        return this.passiveMobs.contains(e);
+        return DefaultMobGroups.PASSIVE.hasMobType(e);
     }
 
     public boolean isMobBoss(EntityType e) {
-        return this.bossMobs.contains(e);
+        return DefaultMobGroups.BOSS.hasMobType(e);
     }
 
     @Override
@@ -438,7 +411,7 @@ public class TradingCards extends TradingCardsPlugin<TradingCard> {
 
     @Override
     public boolean isMob(EntityType type) {
-        return this.hostileMobs.contains(type) || this.neutralMobs.contains(type) || this.passiveMobs.contains(type) || this.bossMobs.contains(type);
+        return DefaultMobGroups.isMob(type);
     }
 
     @Override

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/Storage.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/Storage.java
@@ -3,6 +3,7 @@ package net.tinetwork.tradingcards.tradingcardsplugin.storage;
 import net.tinetwork.tradingcards.api.card.Card;
 import net.tinetwork.tradingcards.api.config.ColorSeries;
 import net.tinetwork.tradingcards.api.model.DropType;
+import net.tinetwork.tradingcards.api.model.MobGroup;
 import net.tinetwork.tradingcards.api.model.Pack;
 import net.tinetwork.tradingcards.api.model.Rarity;
 import net.tinetwork.tradingcards.api.model.Series;
@@ -109,6 +110,8 @@ public interface Storage<T extends Card<T>> {
      * @return Returns a set of all "active" series.
      */
     Set<Series> getActiveSeries();
+
+    MobGroup getMobGroup(String groupId);
 
     /* TODO
      *  @return Returns a <CardsKey, Card> map CardsKey should only be for yaml

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/remote/SqlStorage.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/remote/SqlStorage.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import net.tinetwork.tradingcards.api.card.Card;
 import net.tinetwork.tradingcards.api.config.ColorSeries;
 import net.tinetwork.tradingcards.api.model.DropType;
+import net.tinetwork.tradingcards.api.model.MobGroup;
 import net.tinetwork.tradingcards.api.model.Pack;
 import net.tinetwork.tradingcards.api.model.Rarity;
 import net.tinetwork.tradingcards.api.model.Series;
@@ -780,6 +781,7 @@ public class SqlStorage implements Storage<TradingCard> {
             }
         }.runQuery(SERIES_GET_BY_ID_ACTIVE, null, null);
     }
+
 
     @Override
     public Map<String, TradingCard> getCardsMap() {


### PR DESCRIPTION
Following the idea from #85 this PR aims to do just that.
This is a draft PR but it should be completed before ~~#87~~ is merged to the master branch.

The idea is that you'll be able to create custom mob groups to use with the custom types feature.

- [ ] You should be able to define custom groups with whatever mobs you want.
- [ ] By default all mobs should be their own group as well.