### PR TITLE
Feature placeholderapi

### DIFF
--- a/tradingcards-plugin/pom.xml
+++ b/tradingcards-plugin/pom.xml
@@ -123,7 +123,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.3.0-SNAPSHOT</version>
+                <version>3.3.0</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                     <relocations>

--- a/tradingcards-plugin/pom.xml
+++ b/tradingcards-plugin/pom.xml
@@ -77,6 +77,10 @@
             <url>https://repo.codemc.org/repository/maven-public/</url>
             <layout>default</layout>
         </repository>
+        <repository>
+            <id>placeholderapi</id>
+            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+        </repository>
     </repositories>
     <reporting>
         <plugins>
@@ -183,13 +187,13 @@
     </build>
 
     <dependencies>
+        <!-- Bukkit Libs -->
         <dependency>
             <groupId>net.tinetwork.tradingcards</groupId>
             <artifactId>tradingcards-api</artifactId>
             <version>5.6.0</version>
             <scope>compile</scope>
         </dependency>
-
         <dependency>
             <groupId>co.aikar</groupId>
             <artifactId>acf-paper</artifactId>
@@ -215,6 +219,13 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>me.clip</groupId>
+            <artifactId>placeholderapi</artifactId>
+            <version>2.11.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- Tests -->
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>4.4.0</version>
@@ -226,16 +237,12 @@
             <version>1.13.0</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- DB -->
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
             <version>5.0.1</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>net.lingala.zip4j</groupId>
-            <artifactId>zip4j</artifactId>
-            <version>2.10.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -254,6 +261,13 @@
             <groupId>org.jooq</groupId>
             <artifactId>jooq-codegen</artifactId>
             <version>3.16.5</version>
+            <scope>compile</scope>
+        </dependency>
+        <!-- Others -->
+        <dependency>
+            <groupId>net.lingala.zip4j</groupId>
+            <artifactId>zip4j</artifactId>
+            <version>2.10.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/TradingCards.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/TradingCards.java
@@ -141,6 +141,7 @@ public class TradingCards extends TradingCardsPlugin<TradingCard> {
         initCommands();
 
         hookVault();
+        hookPlaceholderApi();
         new Metrics(this, 12940);
     }
 

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/TradingCards.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/TradingCards.java
@@ -41,6 +41,7 @@ import net.tinetwork.tradingcards.tradingcardsplugin.managers.TradingRarityManag
 import net.tinetwork.tradingcards.tradingcardsplugin.managers.TradingCardManager;
 import net.tinetwork.tradingcards.tradingcardsplugin.managers.TradingDeckManager;
 import net.tinetwork.tradingcards.tradingcardsplugin.managers.TradingSeriesManager;
+import net.tinetwork.tradingcards.tradingcardsplugin.placeholders.TradingCardsPlaceholderExpansion;
 import net.tinetwork.tradingcards.tradingcardsplugin.storage.Storage;
 import net.tinetwork.tradingcards.tradingcardsplugin.storage.StorageType;
 import net.tinetwork.tradingcards.tradingcardsplugin.storage.impl.local.YamlStorage;
@@ -150,6 +151,13 @@ public class TradingCards extends TradingCardsPlugin<TradingCard> {
             Util.logSevereException(e);
         }
         this.storage.init(this);
+    }
+
+
+    private void hookPlaceholderApi() {
+        if(Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
+            new TradingCardsPlaceholderExpansion(this).register();
+        }
     }
 
 

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/TradingCards.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/TradingCards.java
@@ -98,6 +98,7 @@ public class TradingCards extends TradingCardsPlugin<TradingCard> {
     /* Hooks */
     private boolean hasVault;
     private Economy econ = null;
+    private boolean placeholderapi = false;
 
 
     /* Blacklists */
@@ -158,9 +159,13 @@ public class TradingCards extends TradingCardsPlugin<TradingCard> {
     private void hookPlaceholderApi() {
         if(Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
             new TradingCardsPlaceholderExpansion(this).register();
+            placeholderapi = true;
         }
     }
 
+    public boolean placeholderapi() {
+        return placeholderapi;
+    }
 
     public GeneralConfig getGeneralConfig() {
         return generalConfig;

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/BuyCommand.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/BuyCommand.java
@@ -56,7 +56,7 @@ public class BuyCommand extends BaseCommand {
                 if (plugin.getGeneralConfig().closedEconomy()) {
                     plugin.getEcon().bankDeposit(plugin.getGeneralConfig().serverAccount(), pack.getBuyPrice());
                 }
-                ChatUtil.sendPrefixedMessage(player, plugin.getMessagesConfig().boughtCard().replace(PlaceholderUtil.AMOUNT, String.valueOf(pack.getBuyPrice())));
+                ChatUtil.sendPrefixedMessage(player, plugin.getMessagesConfig().boughtCard().replaceAll(PlaceholderUtil.matchAllAsRegEx(PlaceholderUtil.AMOUNT), String.valueOf(pack.getBuyPrice())));
                 CardUtil.dropItem(player, plugin.getPackManager().getPackItem(name));
                 return;
             }
@@ -87,7 +87,8 @@ public class BuyCommand extends BaseCommand {
                     plugin.getEcon().bankDeposit(plugin.getGeneralConfig().serverAccount(), buyPrice);
                 }
                 CardUtil.dropItem(player, tradingCard.build(false));
-                ChatUtil.sendPrefixedMessage(player, plugin.getMessagesConfig().boughtCard().replace(PlaceholderUtil.AMOUNT, String.valueOf(buyPrice)));
+                ChatUtil.sendPrefixedMessage(player,
+                        plugin.getMessagesConfig().boughtCard().replaceAll(PlaceholderUtil.matchAllAsRegEx(PlaceholderUtil.AMOUNT), String.valueOf(buyPrice)));
                 return;
             }
             ChatUtil.sendPrefixedMessage(player, plugin.getMessagesConfig().notEnoughMoney());

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/CardsCommand.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/CardsCommand.java
@@ -71,7 +71,9 @@ public class CardsCommand extends BaseCommand {
     @CommandPermission(Permissions.RESOLVE)
     @Description("Shows a player's uuid")
     public void onResolve(final CommandSender sender, final @NotNull Player player) {
-        ChatUtil.sendMessage(sender, plugin.getMessagesConfig().resolveMsg().replace(PlaceholderUtil.NAME, player.getName()).replace(PlaceholderUtil.UUID, player.getUniqueId().toString()));
+        ChatUtil.sendMessage(sender,
+                plugin.getMessagesConfig().resolveMsg().replaceAll(PlaceholderUtil.matchAllAsRegEx(PlaceholderUtil.NAME),
+                        player.getName()).replaceAll(PlaceholderUtil.matchAllAsRegEx(PlaceholderUtil.UUID), player.getUniqueId().toString()));
     }
 
     @Subcommand("toggle")
@@ -107,11 +109,14 @@ public class CardsCommand extends BaseCommand {
             return;
         }
 
-        Bukkit.broadcastMessage(plugin.getPrefixedMessage(messagesConfig.giveaway().replace(PlaceholderUtil.PLAYER, sender.getName()).replace(PlaceholderUtil.RARITY, getFormattedRarity(rarity))));
+        Bukkit.broadcastMessage(plugin.getPrefixedMessage(messagesConfig.giveaway()
+                .replaceAll(PlaceholderUtil.matchAllAsRegEx(PlaceholderUtil.PLAYER), sender.getName())
+                .replace(PlaceholderUtil.matchAllAsRegEx(PlaceholderUtil.RARITY), getFormattedRarity(rarity))));
         for (final Player p5 : Bukkit.getOnlinePlayers()) {
             CardUtil.dropItem(p5, cardManager.getRandomCard(rarity).build(false));
         }
     }
+
 
     @Subcommand("giveaway entity")
     @CommandPermission(Permissions.GIVEAWAY_ENTITY)
@@ -147,8 +152,9 @@ public class CardsCommand extends BaseCommand {
         final double buyPrice = tradingCard.getBuyPrice();
         final double sellPrice = tradingCard.getSellPrice();
 
-        final String buyMessage = (buyPrice > 0.0D) ? messagesConfig.canBuy().replace(PlaceholderUtil.BUY_AMOUNT, String.valueOf(buyPrice)) : messagesConfig.canNotBuy();
-        final String sellMessage = (sellPrice > 0.0D) ? messagesConfig.canSell().replace(PlaceholderUtil.SELL_AMOUNT, String.valueOf(sellPrice)) : messagesConfig.canNotSell();
+        final String buyMessage = (buyPrice > 0.0D) ?
+                messagesConfig.canBuy().replaceAll(PlaceholderUtil.matchAllAsRegEx(PlaceholderUtil.BUY_AMOUNT), String.valueOf(buyPrice)) : messagesConfig.canNotBuy();
+        final String sellMessage = (sellPrice > 0.0D) ? messagesConfig.canSell().replaceAll(PlaceholderUtil.matchAllAsRegEx(PlaceholderUtil.SELL_AMOUNT), String.valueOf(sellPrice)) : messagesConfig.canNotSell();
         debug("buy=" + buyPrice + "|sell=" + sellPrice);
         ChatUtil.sendPrefixedMessage(player, buyMessage);
         ChatUtil.sendPrefixedMessage(player, sellMessage);

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/GiveCommands.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/GiveCommands.java
@@ -68,8 +68,8 @@ public class GiveCommands extends BaseCommand {
 
 
                 ChatUtil.sendPrefixedMessage(target, plugin.getMessagesConfig().giveCard()
-                        .replace(PlaceholderUtil.PLAYER, target.getName())
-                        .replace(PlaceholderUtil.CARD, rarity + " " + cardName));
+                        .replaceAll(PlaceholderUtil.matchAllAsRegEx(PlaceholderUtil.PLAYER), target.getName())
+                        .replaceAll(PlaceholderUtil.matchAllAsRegEx(PlaceholderUtil.CARD), rarity + " " + cardName));
 
                 target.getInventory().addItem(card.build(shiny));
             }
@@ -96,7 +96,7 @@ public class GiveCommands extends BaseCommand {
 
             CardUtil.dropItem(player, plugin.getPackManager().getPackItem(pack));
 
-            ChatUtil.sendPrefixedMessage(sender, plugin.getMessagesConfig().givePack().replace(PlaceholderUtil.PLAYER, player.getName()).replace(PlaceholderUtil.PACK, pack));
+            ChatUtil.sendPrefixedMessage(sender, plugin.getMessagesConfig().givePack().replaceAll(PlaceholderUtil.matchAllAsRegEx(PlaceholderUtil.PLAYER), player.getName()).replaceAll(PlaceholderUtil.matchAllAsRegEx(PlaceholderUtil.PACK), pack));
             ChatUtil.sendPrefixedMessage(player, plugin.getMessagesConfig().boosterPackMsg());
         }
 
@@ -117,7 +117,8 @@ public class GiveCommands extends BaseCommand {
             try {
                 String rare = plugin.getCardManager().getRandomRarity(CardUtil.getMobType(entityType), true);
                 plugin.debug(getClass(), "Rarity: " + rare);
-                ChatUtil.sendPrefixedMessage(sender, plugin.getMessagesConfig().giveRandomCardMsg().replace(PlaceholderUtil.PLAYER, player.getName()));
+                ChatUtil.sendPrefixedMessage(sender,
+                        plugin.getMessagesConfig().giveRandomCardMsg().replaceAll(PlaceholderUtil.matchAllAsRegEx(PlaceholderUtil.PLAYER), player.getName()));
                 CardUtil.dropItem(player, plugin.getCardManager().getRandomCard(rare).build(false));
             } catch (IllegalArgumentException exception) {
                 ChatUtil.sendPrefixedMessage(player, plugin.getMessagesConfig().noEntity());
@@ -137,7 +138,7 @@ public class GiveCommands extends BaseCommand {
 
 
             plugin.debug(GiveCommands.class, "Rarity: " + rarity);
-            ChatUtil.sendPrefixedMessage(sender, plugin.getMessagesConfig().giveRandomCardMsg().replace(PlaceholderUtil.PLAYER, player.getName()));
+            ChatUtil.sendPrefixedMessage(sender, plugin.getMessagesConfig().giveRandomCardMsg().replaceAll(PlaceholderUtil.matchAllAsRegEx(PlaceholderUtil.PLAYER), player.getName()));
             CardUtil.dropItem(player, plugin.getCardManager().getRandomCard(rarity).build(false));
         }
     }

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/placeholders/TradingCardsPlaceholderExpansion.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/placeholders/TradingCardsPlaceholderExpansion.java
@@ -3,7 +3,6 @@ package net.tinetwork.tradingcards.tradingcardsplugin.placeholders;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import net.tinetwork.tradingcards.tradingcardsplugin.TradingCards;
 import org.bukkit.OfflinePlayer;
-import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -11,7 +10,7 @@ import org.jetbrains.annotations.Nullable;
  * @author sarhatabaot
  */
 public class TradingCardsPlaceholderExpansion extends PlaceholderExpansion {
-    private TradingCards plugin;
+    private final TradingCards plugin;
 
     public TradingCardsPlaceholderExpansion(final TradingCards plugin) {
         this.plugin = plugin;
@@ -38,6 +37,141 @@ public class TradingCardsPlaceholderExpansion extends PlaceholderExpansion {
 
     @Override
     public @Nullable String onRequest(final OfflinePlayer player, @NotNull final String params) {
-        return super.onRequest(player, params);
+        //normal check first
+        if(params.startsWith("type_")) {
+            return new PlaceholderQuery(params){
+                @Override
+                protected String onPlaceholderValue() {
+                    if("display-name".equalsIgnoreCase(type)) {
+                        return plugin.getDropTypeManager().getType(type).getDisplayName();
+                    }
+
+                    if("type".equalsIgnoreCase(type)) {
+                        return plugin.getDropTypeManager().getType(type).getType();
+                    }
+                    return null;
+                }
+
+                @Override
+                public boolean containsType(final String id) {
+                    return plugin.getDropTypeManager().containsType(id);
+                }
+            }.getPlaceholderValue();
+        }
+
+        if(params.startsWith("card_")) {
+            return new PlaceholderQuery(params) {
+                @Override
+                protected String onPlaceholderValue() {
+                    final String rarityId = id.split("\\.")[0];
+                    final String cardId = id.split("\\.")[1];
+                    //final String seriesId = id.split("\\.")[2];
+                    return switch (type) {
+                        case "display-name" -> plugin.getCardManager().getCard(cardId, rarityId).getDisplayName();
+                        case "buy-price" -> String.valueOf(plugin.getCardManager().getCard(cardId, rarityId).getBuyPrice());
+                        case "sell-price" -> String.valueOf(plugin.getCardManager().getCard(cardId, rarityId).getSellPrice());
+                        case "info" -> plugin.getCardManager().getCard(cardId, rarityId).getInfo();
+                        case "about" -> plugin.getCardManager().getCard(cardId, rarityId).getAbout();
+                        case "type" -> plugin.getCardManager().getCard(cardId, rarityId).getType().getId();
+                        default -> null;
+                    };
+                }
+
+                @Override
+                public boolean containsType(final String id) {
+                    final String rarityId = id.split("\\.")[0];
+                    final String cardId = id.split("\\.")[1];
+                    final String seriesId = id.split("\\.")[2];
+                    return plugin.getCardManager().containsCard(cardId,rarityId,seriesId);
+                }
+            }.getPlaceholderValue();
+        }
+
+        if(params.startsWith("pack_")) {
+            return new PlaceholderQuery(params){
+                @Override
+                public String onPlaceholderValue() {
+                    return switch (type) {
+                        case "display-name" -> plugin.getPackManager().getPack(id).getDisplayName();
+                        case "buy-price" ->String.valueOf(plugin.getPackManager().getPack(id).getBuyPrice());
+                        case "permission" -> plugin.getPackManager().getPack(id).getPermission();
+                    };
+                }
+
+                @Override
+                public boolean containsType(final String id) {
+                    return plugin.getPackManager().containsPack(id);
+                }
+            }.getPlaceholderValue();
+        }
+
+        if(params.startsWith("rarity_")) {
+            return new PlaceholderQuery(params){
+                @Override
+                protected String onPlaceholderValue() {
+                    return switch (type) {
+                        case "default-color" -> plugin.getRarityManager().getRarity(id).defaultColor();
+                        case "display-name" -> plugin.getRarityManager().getRarity(id).displayName();
+                        case "buy-price" -> String.valueOf(plugin.getRarityManager().getRarity(id).buyPrice());
+                        case "sell-price" -> String.valueOf(plugin.getRarityManager().getRarity(id).sellPrice());
+                        default -> null;
+                    };
+                }
+
+                @Override
+                public boolean containsType(final String id) {
+                    return plugin.getRarityManager().containsRarity(id);
+                }
+            }.getPlaceholderValue();
+        }
+
+        if(params.startsWith("series_")) {
+            return new PlaceholderQuery(params){
+                @Override
+                protected String onPlaceholderValue() {
+                    if("mode".equalsIgnoreCase(type)) {
+                        return plugin.getSeriesManager().getSeries(id).getMode().name();
+                    }
+                    if("display-name".equalsIgnoreCase(type)) {
+                        return plugin.getSeriesManager().getSeries(id).getDisplayName();
+                    }
+
+                    return null;
+                }
+
+                @Override
+                public boolean containsType(final String id) {
+                    return plugin.getSeriesManager().containsSeries(id);
+                }
+            }.getPlaceholderValue();
+        }
+        if("version".equalsIgnoreCase(params)) {
+            return plugin.getDescription().getVersion();
+        }
+        if("prefix".equalsIgnoreCase(params)){
+            return plugin.getMessagesConfig().prefix();
+        }
+        return null;
     }
+
+
+    public abstract static class PlaceholderQuery {
+        protected String id;
+        protected String type;
+
+        protected PlaceholderQuery(@NotNull String params) {
+            this.id = params.split("_")[1];
+            this.type = params.split("_")[2];
+        }
+        public String getPlaceholderValue() {
+            if(!containsType(id))
+                return null;
+
+            return onPlaceholderValue();
+        }
+        protected abstract String onPlaceholderValue();
+        public abstract boolean containsType(String id);
+    }
+
+
 }

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/placeholders/TradingCardsPlaceholderExpansion.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/placeholders/TradingCardsPlaceholderExpansion.java
@@ -1,0 +1,43 @@
+package net.tinetwork.tradingcards.tradingcardsplugin.placeholders;
+
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import net.tinetwork.tradingcards.tradingcardsplugin.TradingCards;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * @author sarhatabaot
+ */
+public class TradingCardsPlaceholderExpansion extends PlaceholderExpansion {
+    private TradingCards plugin;
+
+    public TradingCardsPlaceholderExpansion(final TradingCards plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public @NotNull String getIdentifier() {
+        return "tc";
+    }
+
+    @Override
+    public @NotNull String getAuthor() {
+        return "sarhatabaot";
+    }
+
+    @Override
+    public @NotNull String getVersion() {
+        return "1.0.0";
+    }
+    @Override
+    public boolean persist() {
+        return true;
+    }
+
+    @Override
+    public @Nullable String onRequest(final OfflinePlayer player, @NotNull final String params) {
+        return super.onRequest(player, params);
+    }
+}

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/Storage.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/Storage.java
@@ -101,6 +101,12 @@ public interface Storage<T extends Card<T>> {
     Series getSeries(final String seriesId);
 
     /**
+     * @param seriesId The seriesId
+     * @return Returns if the series exists.
+     */
+    boolean containsSeries(final String seriesId);
+
+    /**
      * @return Returns a collection of all series
      */
     Collection<Series> getAllSeries();

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/local/YamlStorage.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/local/YamlStorage.java
@@ -152,6 +152,11 @@ public class YamlStorage implements Storage<TradingCard> {
     }
 
     @Override
+    public boolean containsSeries(final String seriesId) {
+        return seriesConfig.series().containsKey(seriesId);
+    }
+
+    @Override
     public void reload() {
         this.raritiesConfig.reloadConfig();
         this.seriesConfig.reloadConfig();

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/remote/SqlStorage.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/remote/SqlStorage.java
@@ -275,6 +275,27 @@ public class SqlStorage implements Storage<TradingCard> {
         }.prepareAndRunQuery();
     }
 
+    @Override
+    public boolean containsSeries(final String seriesId) {
+        return new ExecuteQuery<Boolean,Record>(this,jooqSettings) {
+            @Override
+            public Boolean onRunQuery(final DSLContext dslContext) throws SQLException {
+                return dslContext.fetchExists(net.tinetwork.tradingcards.tradingcardsplugin.storage.impl.remote.generated.tables.Series.SERIES
+                        ,net.tinetwork.tradingcards.tradingcardsplugin.storage.impl.remote.generated.tables.Series.SERIES.SERIES_ID.eq(seriesId));
+            }
+
+            @Override
+            public Boolean getQuery(final @NotNull Record result) throws SQLException {
+                return empty();
+            }
+
+            @Override
+            public Boolean empty() {
+                return false;
+            }
+        }.prepareAndRunQuery();
+    }
+
     public static class StorageEntryComparator implements Comparator<StorageEntry> {
         @Override
         //Implements a simple comparator to allow for sorting

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/utils/CardUtil.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/utils/CardUtil.java
@@ -1,6 +1,7 @@
 package net.tinetwork.tradingcards.tradingcardsplugin.utils;
 
 import de.tr7zw.nbtapi.NBTItem;
+import me.clip.placeholderapi.PlaceholderAPI;
 import net.tinetwork.tradingcards.api.config.ColorSeries;
 import net.tinetwork.tradingcards.api.model.DropType;
 import net.tinetwork.tradingcards.api.model.Rarity;
@@ -169,14 +170,14 @@ public class CardUtil {
     }
 
 
-    public static @NotNull List<String> formatLore(final String info, final String about, final String rarity, final boolean isShiny, final String type, final Series series) {
+    public static @NotNull List<String> formatLore(final String info, final String about, final String rarity, final boolean isShiny, final String type, final @NotNull Series series) {
         List<String> lore = new ArrayList<>();
         final ColorSeries colorSeries = series.getColorSeries();
-        final String typeFormat = ChatUtil.color(colorSeries.getType() + plugin.getGeneralConfig().displayType() + type);
-        final String infoFormat = ChatUtil.color(colorSeries.getInfo() + plugin.getGeneralConfig().displayInfo());
-        final String seriesFormat = ChatUtil.color(colorSeries.getSeries() + plugin.getGeneralConfig().displaySeries() + series.getDisplayName());
-        final String aboutFormat = ChatUtil.color(colorSeries.getAbout() + plugin.getGeneralConfig().displayAbout());
-        final String rarityFormat = ChatUtil.color(colorSeries.getRarity());
+        final String typeFormat = colorSeries.getType() + plugin.getGeneralConfig().displayType() + type;
+        final String infoFormat = colorSeries.getInfo() + plugin.getGeneralConfig().displayInfo();
+        final String seriesFormat = colorSeries.getSeries() + plugin.getGeneralConfig().displaySeries() + series.getDisplayName();
+        final String aboutFormat = colorSeries.getAbout() + plugin.getGeneralConfig().displayAbout();
+        final String rarityFormat = colorSeries.getRarity();
 
         lore.add(typeFormat);
         if (!"None".equalsIgnoreCase(info) && !info.isEmpty()) {
@@ -187,18 +188,26 @@ public class CardUtil {
         }
 
         lore.add(seriesFormat);
-        if (about != null) {
+        if (!"None".equalsIgnoreCase(about) && !about.isEmpty()) {
+            lore.add(aboutFormat);
+            lore.addAll(ChatUtil.wrapString(about));
+        } else {
             lore.add(aboutFormat + about);
         }
 
         final String rarityName = ChatUtil.color(rarity.replace('_', ' '));
-        if (isShiny) {
-            lore.add(ChatUtil.color(rarityFormat + plugin.getGeneralConfig().shinyName() + " " + rarityName));
-        } else {
-            lore.add(ChatUtil.color(rarityFormat + rarityName));
-        }
+        lore.add(getShinyFormat(isShiny,rarityFormat,rarityName));
 
+        lore.forEach(ChatUtil::color);
         return lore;
+    }
+
+    //Returns the format if it's shiny. If it isn't returns the normal format.
+    private static String getShinyFormat(boolean isShiny, String format, String name) {
+        if(isShiny) {
+            return format + plugin.getGeneralConfig().shinyName() + " " + name;
+        }
+        return format + name;
     }
 
 

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/utils/CardUtil.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/utils/CardUtil.java
@@ -199,6 +199,7 @@ public class CardUtil {
         lore.add(getShinyFormat(isShiny,rarityFormat,rarityName));
 
         lore.forEach(ChatUtil::color);
+        lore.forEach(s -> PlaceholderAPI.setPlaceholders(null,s));
         return lore;
     }
 

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/utils/CardUtil.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/utils/CardUtil.java
@@ -33,14 +33,6 @@ public class CardUtil {
     public static final int RANDOM_MAX = 100000;
     public static ItemStack BLANK_CARD;
 
-    private static final String PLACEHOLDER_PREFIX = "%PREFIX%";
-    private static final String PLACEHOLDER_COLOR = "%COLOR%";
-    private static final String PLACEHOLDER_NAME = "%NAME%";
-    private static final String PLACEHOLDER_BUY_PRICE = "%BUY_PRICE%";
-    private static final String PLACEHOLDER_SELL_PRICE = "%SELL_PRICE%";
-    private static final String PLACEHOLDER_SHINY_PREFIX = "%SHINY_PREFIX%";
-    private static final String PLACEHOLDER_SHINY_PREFIX_ALT = "%SHINYPREFIX%";
-    private static final String PLACEHOLDER_PLAYER = "%player%";
 
     private CardUtil() {
         throw new UnsupportedOperationException();
@@ -60,15 +52,15 @@ public class CardUtil {
      */
     public static void dropItem(final @NotNull Player player, final ItemStack item) {
         NBTItem nbtItem = new NBTItem(item);
-        final String debugItem = "name:" +nbtItem.getString(NbtUtils.NBT_CARD_NAME) + " rarity:"+nbtItem.getString(NbtUtils.NBT_RARITY);
+        final String debugItem = "name:" + nbtItem.getString(NbtUtils.NBT_CARD_NAME) + " rarity:" + nbtItem.getString(NbtUtils.NBT_RARITY);
         if (player.getInventory().firstEmpty() != -1) {
             player.getInventory().addItem(item);
-            plugin.debug(CardUtil.class,"Added item "+debugItem+" to "+ player.getName());
+            plugin.debug(CardUtil.class, "Added item " + debugItem + " to " + player.getName());
         } else {
             World playerWorld = player.getWorld();
             if (player.getGameMode() == GameMode.SURVIVAL) {
                 playerWorld.dropItem(player.getLocation(), item);
-                plugin.debug(CardUtil.class,"Dropped item "+debugItem+" @ "+ player.getLocation());
+                plugin.debug(CardUtil.class, "Dropped item " + debugItem + " @ " + player.getLocation());
             }
         }
     }
@@ -88,7 +80,7 @@ public class CardUtil {
     }
 
     public static boolean isCard(final ItemStack itemStack) {
-        if(itemStack == null || itemStack.getType().isAir())
+        if (itemStack == null || itemStack.getType().isAir())
             return false;
         final NBTItem nbtItem = new NBTItem(itemStack);
         return isCard(nbtItem);
@@ -107,46 +99,46 @@ public class CardUtil {
             if (sender == null) {
                 broadcastPrefixedMessage(plugin.getMessagesConfig().giveawayNaturalBossNoPlayer());
             } else {
-                broadcastPrefixedMessage(plugin.getMessagesConfig().giveawayNaturalBoss().replace(PLACEHOLDER_PLAYER, sender.getName()));
+                broadcastPrefixedMessage(plugin.getMessagesConfig().giveawayNaturalBoss().replaceAll(PlaceholderUtil.matchAllAsRegEx(PlaceholderUtil.PLAYER), sender.getName()));
             }
         } else if (plugin.isMobHostile(mob)) {
             if (sender == null) {
                 broadcastPrefixedMessage(plugin.getMessagesConfig().giveawayNaturalHostileNoPlayer());
             } else {
-                broadcastPrefixedMessage(plugin.getMessagesConfig().giveawayNaturalHostile().replace(PLACEHOLDER_PLAYER, sender.getName()));
+                broadcastPrefixedMessage(plugin.getMessagesConfig().giveawayNaturalHostile().replace(PlaceholderUtil.matchAllAsRegEx(PlaceholderUtil.PLAYER), sender.getName()));
             }
         } else if (plugin.isMobNeutral(mob)) {
             if (sender == null) {
                 broadcastPrefixedMessage(plugin.getPrefixedMessage(plugin.getMessagesConfig().giveawayNaturalNeutralNoPlayer()));
             } else {
-                broadcastPrefixedMessage(plugin.getPrefixedMessage(plugin.getMessagesConfig().giveawayNaturalNeutral().replace(PLACEHOLDER_PLAYER, sender.getName())));
+                broadcastPrefixedMessage(plugin.getPrefixedMessage(plugin.getMessagesConfig().giveawayNaturalNeutral().replace(PlaceholderUtil.matchAllAsRegEx(PlaceholderUtil.PLAYER), sender.getName())));
             }
         } else if (plugin.isMobPassive(mob)) {
             if (sender == null) {
                 broadcastPrefixedMessage(plugin.getPrefixedMessage(plugin.getMessagesConfig().giveawayNaturalPassiveNoPlayer()));
             } else {
-                broadcastPrefixedMessage(plugin.getPrefixedMessage(plugin.getMessagesConfig().giveawayNaturalPassive().replace(PLACEHOLDER_PLAYER, sender.getName())));
+                broadcastPrefixedMessage(plugin.getPrefixedMessage(plugin.getMessagesConfig().giveawayNaturalPassive().replaceAll(PlaceholderUtil.matchAllAsRegEx(PlaceholderUtil.PLAYER), sender.getName())));
             }
         } else if (sender == null) {
             broadcastPrefixedMessage(plugin.getMessagesConfig().giveawayNaturalNoPlayer());
         } else {
-            broadcastPrefixedMessage(plugin.getMessagesConfig().giveawayNatural().replace(PLACEHOLDER_PLAYER, sender.getName()));
+            broadcastPrefixedMessage(plugin.getMessagesConfig().giveawayNatural().replaceAll(PlaceholderUtil.matchAllAsRegEx(PlaceholderUtil.PLAYER), sender.getName()));
         }
 
         for (final Player p : Bukkit.getOnlinePlayers()) {
             String rare = cardManager.getRandomRarity(CardUtil.getMobType(mob), true);
-            plugin.debug(CardUtil.class,"onCommand.rare: " + rare);
+            plugin.debug(CardUtil.class, "onCommand.rare: " + rare);
             CardUtil.dropItem(p, cardManager.getRandomCard(rare).build(false));
         }
 
     }
 
     public static @NotNull String formatDisplayName(final @NotNull TradingCard card, boolean shiny) {
-        final String[] shinyPlayerCardFormat = new String[]{PLACEHOLDER_PREFIX, PLACEHOLDER_COLOR, PLACEHOLDER_NAME, PLACEHOLDER_BUY_PRICE, PLACEHOLDER_SELL_PRICE, PLACEHOLDER_SHINY_PREFIX};
-        final String[] shinyCardFormat = new String[]{PLACEHOLDER_PREFIX, PLACEHOLDER_COLOR, PLACEHOLDER_NAME, PLACEHOLDER_BUY_PRICE, PLACEHOLDER_SELL_PRICE, PLACEHOLDER_SHINY_PREFIX, "_"};
+        final String[] shinyPlayerCardFormat = new String[]{PlaceholderUtil.PREFIX, PlaceholderUtil.COLOR, PlaceholderUtil.NAME, PlaceholderUtil.BUY_PRICE, PlaceholderUtil.SELL_PRICE, PlaceholderUtil.SHINY_PREFIX};
+        final String[] shinyCardFormat = new String[]{PlaceholderUtil.PREFIX, PlaceholderUtil.COLOR, PlaceholderUtil.NAME, PlaceholderUtil.BUY_PRICE, PlaceholderUtil.SELL_PRICE, PlaceholderUtil.SHINY_PREFIX, "_"};
 
-        final String[] cardFormat = new String[]{PLACEHOLDER_PREFIX, PLACEHOLDER_COLOR, PLACEHOLDER_NAME, PLACEHOLDER_BUY_PRICE, PLACEHOLDER_SELL_PRICE, "_"};
-        final String[] playerCardFormat = new String[]{PLACEHOLDER_PREFIX, PLACEHOLDER_COLOR, PLACEHOLDER_NAME, PLACEHOLDER_BUY_PRICE, PLACEHOLDER_SELL_PRICE};
+        final String[] cardFormat = new String[]{PlaceholderUtil.PREFIX, PlaceholderUtil.COLOR, PlaceholderUtil.NAME, PlaceholderUtil.BUY_PRICE, PlaceholderUtil.SELL_PRICE, "_"};
+        final String[] playerCardFormat = new String[]{PlaceholderUtil.PREFIX, PlaceholderUtil.COLOR, PlaceholderUtil.NAME, PlaceholderUtil.BUY_PRICE, PlaceholderUtil.SELL_PRICE};
 
         Rarity rarity = card.getRarity();
         final String shinyTitle = plugin.getGeneralConfig().displayShinyTitle();
@@ -157,16 +149,24 @@ public class CardUtil {
         final String buyPrice = String.valueOf(card.getBuyPrice());
         final String sellPrice = String.valueOf(card.getSellPrice());
 
+        String finalTitle;
         if (shiny && shinyPrefix != null) {
             if (card.isPlayerCard()) {
-                return ChatUtil.color(StringUtils.replaceEach(shinyTitle.replace(PLACEHOLDER_SHINY_PREFIX_ALT,PLACEHOLDER_SHINY_PREFIX), shinyPlayerCardFormat, new String[]{prefix, rarityColour, card.getDisplayName(), buyPrice, sellPrice, shinyPrefix}));
+                finalTitle = ChatUtil.color(StringUtils.replaceEach(shinyTitle.replaceAll(PlaceholderUtil.matchAllAsRegEx(PlaceholderUtil.SHINY_PREFIX_ALT), PlaceholderUtil.matchAllAsRegEx(PlaceholderUtil.SHINY_PREFIX)), shinyPlayerCardFormat, new String[]{prefix, rarityColour, card.getDisplayName(), buyPrice, sellPrice, shinyPrefix}));
+            } else {
+                finalTitle = ChatUtil.color(StringUtils.replaceEach(shinyTitle.replace(PlaceholderUtil.SHINY_PREFIX_ALT, PlaceholderUtil.SHINY_PREFIX), shinyCardFormat, new String[]{prefix, rarityColour, card.getDisplayName(), buyPrice, sellPrice, shinyPrefix, " "}));
             }
-            return ChatUtil.color(StringUtils.replaceEach(shinyTitle.replace(PLACEHOLDER_SHINY_PREFIX_ALT,PLACEHOLDER_SHINY_PREFIX), shinyCardFormat, new String[]{prefix, rarityColour, card.getDisplayName(), buyPrice, sellPrice, shinyPrefix, " "}));
+        } else {
+            if (card.isPlayerCard()) {
+                finalTitle = ChatUtil.color(StringUtils.replaceEach(title, playerCardFormat, new String[]{prefix, rarityColour, card.getDisplayName(), buyPrice, sellPrice}));
+            } else {
+                finalTitle = ChatUtil.color(StringUtils.replaceEach(title, cardFormat, new String[]{prefix, rarityColour, card.getDisplayName(), buyPrice, sellPrice, " "}));
+            }
         }
-        if (card.isPlayerCard()) {
-            return ChatUtil.color(StringUtils.replaceEach(title, playerCardFormat, new String[]{prefix, rarityColour, card.getDisplayName(), buyPrice, sellPrice}));
+        if (plugin.placeholderapi()) {
+            return PlaceholderAPI.setPlaceholders(null, finalTitle);
         }
-        return ChatUtil.color(StringUtils.replaceEach(title, cardFormat, new String[]{prefix, rarityColour, card.getDisplayName(), buyPrice, sellPrice, " "}));
+        return finalTitle;
     }
 
 
@@ -180,7 +180,7 @@ public class CardUtil {
         final String rarityFormat = colorSeries.getRarity();
 
         lore.add(typeFormat);
-        if (!"None".equalsIgnoreCase(info) && !info.isEmpty()) {
+        if (!"none".equalsIgnoreCase(info) && !info.isEmpty()) {
             lore.add(infoFormat);
             lore.addAll(ChatUtil.wrapString(info));
         } else {
@@ -188,7 +188,7 @@ public class CardUtil {
         }
 
         lore.add(seriesFormat);
-        if (!"None".equalsIgnoreCase(about) && !about.isEmpty()) {
+        if (!"none".equalsIgnoreCase(about) && !about.isEmpty()) {
             lore.add(aboutFormat);
             lore.addAll(ChatUtil.wrapString(about));
         } else {
@@ -196,25 +196,26 @@ public class CardUtil {
         }
 
         final String rarityName = ChatUtil.color(rarity.replace('_', ' '));
-        lore.add(getShinyFormat(isShiny,rarityFormat,rarityName));
+        lore.add(getShinyFormat(isShiny, rarityFormat, rarityName));
 
         lore.forEach(ChatUtil::color);
-        lore.forEach(s -> PlaceholderAPI.setPlaceholders(null,s));
+        if(plugin.placeholderapi()) {
+            lore.forEach(s -> PlaceholderAPI.setPlaceholders(null, s));
+        }
         return lore;
     }
 
     //Returns the format if it's shiny. If it isn't returns the normal format.
     private static String getShinyFormat(boolean isShiny, String format, String name) {
-        if(isShiny) {
+        if (isShiny) {
             return format + plugin.getGeneralConfig().shinyName() + " " + name;
         }
         return format + name;
     }
 
 
-
     @Contract(pure = true)
-    public static @NotNull String cardKey(@NotNull final String rarityId,@NotNull final String cardId) {
+    public static @NotNull String cardKey(@NotNull final String rarityId, @NotNull final String cardId) {
         return rarityId + "." + cardId;
     }
 
@@ -223,7 +224,7 @@ public class CardUtil {
             return true;
         int shinyRandom = plugin.getRandom().nextInt(CardUtil.RANDOM_MAX) + 1;
         boolean isShiny = shinyRandom <= plugin.getChancesConfig().shinyVersionChance();
-        plugin.debug(TradingCardManager.class,"Shiny="+isShiny+", Value="+shinyRandom+", ShinyChance="+plugin.getChancesConfig().shinyVersionChance());
+        plugin.debug(TradingCardManager.class, "Shiny=" + isShiny + ", Value=" + shinyRandom + ", ShinyChance=" + plugin.getChancesConfig().shinyVersionChance());
         return isShiny;
     }
 

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/utils/PlaceholderUtil.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/utils/PlaceholderUtil.java
@@ -1,5 +1,8 @@
 package net.tinetwork.tradingcards.tradingcardsplugin.utils;
 
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
 /**
  * @author sarhatabaot
  */
@@ -17,4 +20,9 @@ public class PlaceholderUtil {
     public static final String BUY_AMOUNT = "%buyAmount%";
     public static final String SELL_AMOUNT = "%sellAmount%";
     public static final String AMOUNT = "%amount%";
+
+    @Contract(pure = true)
+    public static @NotNull String matchAllAsRegEx(final String string) {
+        return "(?i)"+string;
+    }
 }

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/utils/PlaceholderUtil.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/utils/PlaceholderUtil.java
@@ -17,8 +17,14 @@ public class PlaceholderUtil {
     public static final String NAME = "%name%";
     public static final String UUID = "%uuid%";
     public static final String RARITY = "%rarity%";
-    public static final String BUY_AMOUNT = "%buyAmount%";
-    public static final String SELL_AMOUNT = "%sellAmount%";
+    public static final String BUY_AMOUNT = "%buyamount%";
+    public static final String SELL_AMOUNT = "%sellamount%";
+    public static final String PREFIX = "%prefix%";
+    public static final String COLOR = "%color%";
+    public static final String BUY_PRICE = "%buy_price%";
+    public static final String SELL_PRICE = "%sell_price%";
+    public static final String SHINY_PREFIX = "%shiny_prefix%";
+    public static final String SHINY_PREFIX_ALT = "%shinyprefix%";
     public static final String AMOUNT = "%amount%";
 
     @Contract(pure = true)

--- a/tradingcards-plugin/src/main/resources/plugin.yml
+++ b/tradingcards-plugin/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: TradingCards
 main: net.tinetwork.tradingcards.tradingcardsplugin.TradingCards
 version: ${project.version}
-softdepend: [Vault]
+softdepend: [Vault,PlaceholderAPI]
 authors: [Xenoyia, sarhatabaot, TreasureIslandMC]
 api-version: "1.17"
 libraries:


### PR DESCRIPTION
This PR will add PlaceholderAPI support.

- [x] Add some placeholders. See list below: "Placeholders".
- [ ] Add support for placeholders in messages. See own PR for this.
- [x] Add support for placeholders in card lore.
- [x] Add support for placeholders in card title.

Placholders:
All `{id}` are written as is. Without the brackets. For example: 
if our type id is "ranks" we would use: `%tc_type_ranks_display-name%`.
- `%tc_version%`
- `%tc_prefix%`
- `%tc_type_{id}_display-name%`
- `%tc_type_{id}_type%`
- `%tc_card_{rarityId.cardId.seriesId}_display-name%`
- `%tc_card_{rarityId.cardId.seriesId}_buy-price%`
- `%tc_card_{rarityId.cardId.seriesId}_sell-price%`
- `%tc_card_{rarityId.cardId.seriesId}_info%`
- `%tc_card_{rarityId.cardId.seriesId}_about%`
- `%tc_card_{rarityId.cardId.seriesId}_type%`
- `%tc_pack_{id}_display-name%`
- `%tc_pack_{id}_buy-price%`
- `%tc_pack_{id}_permission%`
- `%tc_series_{id}_display-name%`
- `%tc_series_{id}_mode%`
- `%tc_rarity_{id}_display-name%`
- `%tc_rarity_{id}_default-color%`
- `%tc_rarity_{id}_buy-price%`
- `%tc_rarity_{id}_sell-price%`