### PR TITLE
Changed to using NBTCompound "trading_cards"

### DIFF
--- a/tradingcards-api/src/main/java/net/tinetwork/tradingcards/api/card/Card.java
+++ b/tradingcards-api/src/main/java/net/tinetwork/tradingcards/api/card/Card.java
@@ -1,5 +1,6 @@
 package net.tinetwork.tradingcards.api.card;
 
+import de.tr7zw.nbtapi.NBTCompound;
 import de.tr7zw.nbtapi.NBTItem;
 import net.tinetwork.tradingcards.api.model.DropType;
 import net.tinetwork.tradingcards.api.model.Rarity;
@@ -8,6 +9,7 @@ import net.tinetwork.tradingcards.api.utils.NbtUtils;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public abstract class Card<T>{
     private final String cardId;
@@ -71,7 +73,7 @@ public abstract class Card<T>{
      * @param data custom model nbt
      * @return Builder
      */
-    public Card<T> customModelNbt(final int data) {
+    public Card<T> customModelNbt(final Integer data) {
         this.cardMeta.setCustomModelNbt(data);
         return this;
     }
@@ -179,12 +181,17 @@ public abstract class Card<T>{
 
     public NBTItem buildNBTItem(boolean shiny) {
         NBTItem nbtItem = new NBTItem(buildItem(shiny));
-        nbtItem.setString(NbtUtils.NBT_CARD_NAME, cardId);
-        nbtItem.setString(NbtUtils.NBT_RARITY,rarity.getId());
-        nbtItem.setBoolean(NbtUtils.NBT_IS_CARD, true);
-        nbtItem.setBoolean(NbtUtils.NBT_CARD_SHINY, shiny);
-        nbtItem.setString(NbtUtils.NBT_CARD_SERIES,series.getId());
-        nbtItem.setInteger(NbtUtils.NBT_CARD_CUSTOM_MODEL, this.cardMeta.getCustomModelNbt());
+        NBTCompound nbtCompound = nbtItem.getOrCreateCompound(NbtUtils.NBT_TRADING_CARDS_COMPOUND);
+        nbtCompound.setString(NbtUtils.Legacy.NBT_CARD_NAME, cardId);
+        nbtCompound.setString(NbtUtils.Legacy.NBT_RARITY,rarity.getId());
+        nbtCompound.setBoolean(NbtUtils.Legacy.NBT_IS_CARD, true);
+        nbtCompound.setBoolean(NbtUtils.Legacy.NBT_CARD_SHINY, shiny);
+        nbtCompound.setString(NbtUtils.Legacy.NBT_CARD_SERIES,series.getId());
+
+        if(getCustomModelNbt() != 0) {
+            nbtItem.setInteger(NbtUtils.Legacy.NBT_CARD_CUSTOM_MODEL, this.cardMeta.getCustomModelNbt());
+        }
+
         return nbtItem;
     }
 

--- a/tradingcards-api/src/main/java/net/tinetwork/tradingcards/api/card/Card.java
+++ b/tradingcards-api/src/main/java/net/tinetwork/tradingcards/api/card/Card.java
@@ -9,7 +9,6 @@ import net.tinetwork.tradingcards.api.utils.NbtUtils;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 public abstract class Card<T>{
     private final String cardId;

--- a/tradingcards-api/src/main/java/net/tinetwork/tradingcards/api/utils/NbtUtils.java
+++ b/tradingcards-api/src/main/java/net/tinetwork/tradingcards/api/utils/NbtUtils.java
@@ -13,27 +13,97 @@ import java.util.Objects;
  properly anymore.!!
  */
 public class NbtUtils {
-    //Deck Item
-    public static final String NBT_DECK_NUMBER = "deckNumber";
-    public static final String NBT_IS_DECK = "isDeck";
+    public static final String NBT_TRADING_CARDS_COMPOUND = "trading_cards";
 
-    //Card Item
-    public static final String NBT_IS_CARD = "isCard";
-    public static final String NBT_CARD_NAME = "name";
-    public static final String NBT_RARITY = "rarity";
-    public static final String NBT_CARD_SHINY = "shiny";
-    public static final String NBT_CARD_SERIES = "series";
-    public static final String NBT_CARD_CUSTOM_MODEL = "CustomModelData";
+    public static class Legacy {
+        //Deck Item
+        public static final String NBT_DECK_NUMBER = "deckNumber";
+        public static final String NBT_IS_DECK = "isDeck";
 
-    //Pack Item
-    public static final String NBT_PACK = "pack";
-    public static final String NBT_PACK_ID = "packId";
+        //Card Item
+        public static final String NBT_IS_CARD = "isCard";
+        public static final String NBT_CARD_NAME = "name";
+        public static final String NBT_RARITY = "rarity";
+        public static final String NBT_CARD_SHINY = "shiny";
+        public static final String NBT_CARD_SERIES = "series";
+        public static final String NBT_CARD_CUSTOM_MODEL = "CustomModelData";
+
+        //Pack Item
+        public static final String NBT_PACK = "pack";
+        public static final String NBT_PACK_ID = "packId";
 
 
-    public static boolean isCardSimilar(final @NotNull NBTItem item1, final @NotNull NBTItem item2) {
-        return Objects.equals(item1.getBoolean(NBT_CARD_SHINY), item2.getBoolean(NBT_CARD_SHINY)) &&
-                item1.getString(NBT_CARD_NAME).equals(item2.getString(NBT_CARD_NAME)) &&
-                item1.getString(NBT_RARITY).equals(item2.getString(NBT_RARITY)) &&
-                item1.getString(NBT_CARD_SERIES).equals(item2.getString(NBT_CARD_SERIES));
+        //Compare 2 "legacy" cards items
+        public static boolean isCardSimilarLegacy(final @NotNull NBTItem item1, final @NotNull NBTItem item2) {
+            return Objects.equals(item1.getBoolean(NBT_CARD_SHINY), item2.getBoolean(NBT_CARD_SHINY)) &&
+                    item1.getString(NBT_CARD_NAME).equals(item2.getString(NBT_CARD_NAME)) &&
+                    item1.getString(NBT_RARITY).equals(item2.getString(NBT_RARITY)) &&
+                    item1.getString(NBT_CARD_SERIES).equals(item2.getString(NBT_CARD_SERIES));
+        }
+    }
+
+    public static class Deck {
+        public static int getDeckNumber(final @NotNull NBTItem item) {
+            if(isLegacy(item)) {
+                return item.getInteger(Legacy.NBT_DECK_NUMBER);
+            }
+            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).getInteger(Legacy.NBT_DECK_NUMBER);
+        }
+
+        public static boolean isDeck(final @NotNull NBTItem item) {
+            if(isLegacy(item))
+                return item.getBoolean(Legacy.NBT_IS_DECK);
+            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).getBoolean(Legacy.NBT_IS_DECK);
+        }
+    }
+
+    public static class Card {
+        public static String getCardId(final @NotNull NBTItem item) {
+            if(isLegacy(item))
+                return item.getString(Legacy.NBT_CARD_NAME);
+            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).getString(Legacy.NBT_CARD_NAME);
+        }
+
+        public static String getRarityId(final @NotNull NBTItem item) {
+            if(isLegacy(item))
+                return item.getString(Legacy.NBT_RARITY);
+            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).getString(Legacy.NBT_RARITY);
+        }
+
+        public static String getSeriesId(final @NotNull NBTItem item) {
+            if(isLegacy(item))
+                return item.getString(Legacy.NBT_CARD_SERIES);
+            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).getString(Legacy.NBT_CARD_SERIES);
+        }
+
+        public static boolean isShiny(final @NotNull NBTItem item) {
+            if(isLegacy(item))
+                return item.getBoolean(Legacy.NBT_CARD_SHINY);
+            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).getBoolean(Legacy.NBT_CARD_SHINY);
+        }
+
+        public static boolean isCard(final @NotNull NBTItem item) {
+            if(isLegacy(item))
+                return item.getBoolean(Legacy.NBT_IS_CARD);
+            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).getBoolean(Legacy.NBT_IS_CARD);
+        }
+    }
+
+    public static class Pack {
+        public static String getPackId(final @NotNull NBTItem item) {
+            if(isLegacy(item))
+                return item.getString(Legacy.NBT_PACK_ID);
+            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).getString(Legacy.NBT_PACK_ID);
+        }
+        public static boolean isPack(final @NotNull NBTItem item) {
+            if(isLegacy(item))
+                return item.getBoolean(Legacy.NBT_PACK);
+            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).getBoolean(Legacy.NBT_PACK);
+        }
+    }
+
+
+    public static boolean isLegacy(final @NotNull NBTItem item) {
+        return item.getCompound(NBT_TRADING_CARDS_COMPOUND) == null;
     }
 }

--- a/tradingcards-api/src/main/java/net/tinetwork/tradingcards/api/utils/NbtUtils.java
+++ b/tradingcards-api/src/main/java/net/tinetwork/tradingcards/api/utils/NbtUtils.java
@@ -15,6 +15,10 @@ import java.util.Objects;
 public class NbtUtils {
     public static final String NBT_TRADING_CARDS_COMPOUND = "trading_cards";
 
+    private NbtUtils() {
+        throw new UnsupportedOperationException();
+    }
+
     public static class Legacy {
         //Deck Item
         public static final String NBT_DECK_NUMBER = "deckNumber";
@@ -32,6 +36,9 @@ public class NbtUtils {
         public static final String NBT_PACK = "pack";
         public static final String NBT_PACK_ID = "packId";
 
+        private Legacy() {
+            throw new UnsupportedOperationException();
+        }
 
         //Compare 2 "legacy" cards items
         public static boolean isCardSimilarLegacy(final @NotNull NBTItem item1, final @NotNull NBTItem item2) {
@@ -43,6 +50,9 @@ public class NbtUtils {
     }
 
     public static class Deck {
+        private Deck() {
+            throw new UnsupportedOperationException();
+        }
         public static int getDeckNumber(final @NotNull NBTItem item) {
             if(isLegacy(item)) {
                 return item.getInteger(Legacy.NBT_DECK_NUMBER);
@@ -58,6 +68,10 @@ public class NbtUtils {
     }
 
     public static class Card {
+        private Card() {
+            throw new UnsupportedOperationException();
+        }
+
         public static String getCardId(final @NotNull NBTItem item) {
             if(isLegacy(item))
                 return item.getString(Legacy.NBT_CARD_NAME);
@@ -90,6 +104,10 @@ public class NbtUtils {
     }
 
     public static class Pack {
+        private Pack() {
+            throw new UnsupportedOperationException();
+        }
+
         public static String getPackId(final @NotNull NBTItem item) {
             if(isLegacy(item))
                 return item.getString(Legacy.NBT_PACK_ID);

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/CardsCommand.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/CardsCommand.java
@@ -97,9 +97,9 @@ public class CardsCommand extends BaseCommand {
             return;
         }
 
-        final String cardId = nbtItem.getString(NbtUtils.NBT_CARD_NAME);
-        final String rarityId = nbtItem.getString(NbtUtils.NBT_RARITY);
-        final String seriesId = nbtItem.getString(NbtUtils.NBT_CARD_SERIES);
+        final String cardId = NbtUtils.Card.getCardId(nbtItem);
+        final String rarityId = NbtUtils.Card.getRarityId(nbtItem);
+        final String seriesId = NbtUtils.Card.getSeriesId(nbtItem);
         debug(InternalDebug.CardsCommand.CARD_RARITY_ID.formatted(cardId,rarityId));
 
         final TradingCard tradingCard = cardManager.getCard(cardId, rarityId, seriesId);

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/SellCommand.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/SellCommand.java
@@ -47,9 +47,9 @@ public class SellCommand extends BaseCommand {
 
             final ItemStack itemInHand = player.getInventory().getItemInMainHand();
             final int itemInHandSlot = player.getInventory().getHeldItemSlot();
-            final String cardId = nbtItem.getString(NbtUtils.NBT_CARD_NAME);
-            final String rarityId = nbtItem.getString(NbtUtils.NBT_RARITY);
-            final String seriesId = nbtItem.getString(NbtUtils.NBT_CARD_SERIES);
+            final String cardId = NbtUtils.Card.getCardId(nbtItem);
+            final String rarityId = NbtUtils.Card.getRarityId(nbtItem);
+            final String seriesId = NbtUtils.Card.getSeriesId(nbtItem);
             plugin.debug(SellSubCommand.class, InternalDebug.CardsCommand.CARD_RARITY_ID.formatted(cardId,rarityId));
 
             final TradingCard tradingCard = plugin.getCardManager().getCard(cardId, rarityId, seriesId);

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/config/transformations/AdvancedTransformations.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/config/transformations/AdvancedTransformations.java
@@ -23,7 +23,6 @@ public class AdvancedTransformations extends Transformation {
                 .build();
     }
 
-    //todo we want to set every child of cache to a refresh after write value of 5
     private ConfigurationTransformation updateDefaultRefreshAfterWrite() {
         return ConfigurationTransformation.builder()
                 .addAction(path("cache", ConfigurationTransformation.WILDCARD_OBJECT), (path, value) -> {

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/events/DeckEventListener.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/events/DeckEventListener.java
@@ -59,7 +59,7 @@ public class DeckEventListener extends SimpleListener {
 
 
         NBTItem nbtItem = new NBTItem(event.getItem());
-        if(!nbtItem.getBoolean(NbtUtils.NBT_IS_CARD)) {
+        if(!NbtUtils.Card.isCard(nbtItem)) {
             //not a card, ignoring
             return;
         }
@@ -80,7 +80,7 @@ public class DeckEventListener extends SimpleListener {
         int amount = 0;
         for(ItemStack itemStack: inventory.getContents()) {
             NBTItem currentItem = new NBTItem(itemStack);
-            if(NbtUtils.isCardSimilar(currentItem,nbtItem)) {
+            if(NbtUtils.Legacy.isCardSimilarLegacy(currentItem,nbtItem)) {
                 amount += currentItem.getItem().getAmount();
             }
         }

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/listeners/DeckListener.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/listeners/DeckListener.java
@@ -80,10 +80,10 @@ public class DeckListener extends SimpleListener {
 
     private @NotNull StorageEntry formatEntryString(final ItemStack itemStack) {
         NBTItem nbtItem = new NBTItem(itemStack);
-        final String cardId = nbtItem.getString(NbtUtils.NBT_CARD_NAME);
-        final String rarity = nbtItem.getString(NbtUtils.NBT_RARITY);
-        final boolean shiny = nbtItem.getBoolean(NbtUtils.NBT_CARD_SHINY);
-        final String seriesId = nbtItem.getString(NbtUtils.NBT_CARD_SERIES);
+        final String cardId = NbtUtils.Card.getCardId(nbtItem);
+        final String rarity = NbtUtils.Card.getRarityId(nbtItem);
+        final boolean shiny = NbtUtils.Card.isShiny(nbtItem);
+        final String seriesId = NbtUtils.Card.getSeriesId(nbtItem);
         return new StorageEntry(rarity, cardId, itemStack.getAmount(), shiny,seriesId);
     }
 }

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/listeners/PackListener.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/listeners/PackListener.java
@@ -61,7 +61,7 @@ public class PackListener extends SimpleListener {
             return;
         }
         NBTItem nbtPackItem = new NBTItem(itemInMainHand);
-        final String packId = nbtPackItem.getString(NbtUtils.NBT_PACK_ID);
+        final String packId = NbtUtils.Pack.getPackId(nbtPackItem);
         if(packId == null) {
             return;
         }

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/managers/BoosterPackManager.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/managers/BoosterPackManager.java
@@ -99,7 +99,6 @@ public class BoosterPackManager extends Manager<String, Pack> implements PackMan
     }
 
     @Override
-    //todo nbt compound
     public ItemStack generatePack(final @NotNull Pack pack) {
         ItemStack itemPack = blankPack.clone();
         ItemMeta itemPackMeta = itemPack.getItemMeta();

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/managers/BoosterPackManager.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/managers/BoosterPackManager.java
@@ -3,6 +3,7 @@ package net.tinetwork.tradingcards.tradingcardsplugin.managers;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import de.tr7zw.nbtapi.NBTCompound;
 import de.tr7zw.nbtapi.NBTItem;
 import net.tinetwork.tradingcards.api.manager.PackManager;
 import net.tinetwork.tradingcards.api.model.Pack;
@@ -98,6 +99,7 @@ public class BoosterPackManager extends Manager<String, Pack> implements PackMan
     }
 
     @Override
+    //todo nbt compound
     public ItemStack generatePack(final @NotNull Pack pack) {
         ItemStack itemPack = blankPack.clone();
         ItemMeta itemPackMeta = itemPack.getItemMeta();
@@ -121,13 +123,14 @@ public class BoosterPackManager extends Manager<String, Pack> implements PackMan
         itemPackMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
         itemPack.setItemMeta(itemPackMeta);
         NBTItem nbtItem = new NBTItem(itemPack);
-        nbtItem.setString(NbtUtils.NBT_PACK_ID, pack.id());
-        nbtItem.setBoolean(NbtUtils.NBT_PACK, true);
+        NBTCompound compound = nbtItem.getOrCreateCompound(NbtUtils.NBT_TRADING_CARDS_COMPOUND);
+        compound.setString(NbtUtils.Legacy.NBT_PACK_ID, pack.id());
+        compound.setBoolean(NbtUtils.Legacy.NBT_PACK,true);
         return nbtItem.getItem();
     }
 
     public boolean isPack(final ItemStack item) {
-        return new NBTItem(item).getBoolean(NbtUtils.NBT_PACK);
+        return NbtUtils.Pack.isPack(new NBTItem(item));
     }
 
     @Override

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/managers/DropTypeManager.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/managers/DropTypeManager.java
@@ -1,7 +1,6 @@
 package net.tinetwork.tradingcards.tradingcardsplugin.managers;
 
 
-import com.github.sarhatabaot.kraken.core.logging.LoggerUtil;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -17,7 +16,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 public class DropTypeManager extends Manager<String, DropType> implements TypeManager {

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/managers/DropTypeManager.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/managers/DropTypeManager.java
@@ -1,6 +1,7 @@
 package net.tinetwork.tradingcards.tradingcardsplugin.managers;
 
 
+import com.github.sarhatabaot.kraken.core.logging.LoggerUtil;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -16,14 +17,15 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 public class DropTypeManager extends Manager<String, DropType> implements TypeManager {
     private static final String HOSTILE_ID  = "hostile";
     private static final String NEUTRAL_ID = "neutral";
     private static final String PASSIVE_ID = "passive";
-    private static final String BOSS_ID = "bossId";
-    private static final String ALL_ID = "allId";
+    private static final String BOSS_ID = "boss";
+    private static final String ALL_ID = "all";
 
     public static final Map<String,DropType> DEFAULT_MOB_TYPES = Map.of(
             HOSTILE_ID, new DropType(HOSTILE_ID,"Hostile", HOSTILE_ID),

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/managers/TradingDeckManager.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/managers/TradingDeckManager.java
@@ -1,5 +1,6 @@
 package net.tinetwork.tradingcards.tradingcardsplugin.managers;
 
+import de.tr7zw.nbtapi.NBTCompound;
 import de.tr7zw.nbtapi.NBTItem;
 import net.tinetwork.tradingcards.api.events.DeckCloseEvent;
 import net.tinetwork.tradingcards.api.events.DeckOpenEvent;
@@ -163,10 +164,12 @@ public class TradingDeckManager implements DeckManager {
 
     @NotNull
     @Override
+    //todo nbtcompound
     public ItemStack getNbtItem(@NotNull final Player player, final int deckNumber) {
         NBTItem nbtItem = new NBTItem(createDeckItem(player, deckNumber));
-        nbtItem.setBoolean(NbtUtils.NBT_IS_DECK, true);
-        nbtItem.setInteger(NbtUtils.NBT_DECK_NUMBER, deckNumber);
+        NBTCompound nbtCompound = nbtItem.getOrCreateCompound(NbtUtils.NBT_TRADING_CARDS_COMPOUND);
+        nbtCompound.setBoolean(NbtUtils.Legacy.NBT_IS_DECK, true);
+        nbtCompound.setInteger(NbtUtils.Legacy.NBT_DECK_NUMBER, deckNumber);
         return nbtItem.getItem();
     }
 
@@ -178,13 +181,13 @@ public class TradingDeckManager implements DeckManager {
     public boolean isDeck(final @NotNull ItemStack item) {
         if (item.getType() == Material.AIR)
             return false;
-        return new NBTItem(item).getBoolean(NbtUtils.NBT_IS_DECK);
+        return NbtUtils.Deck.isDeck(new NBTItem(item));
     }
 
     public int getDeckNumber(final ItemStack item) {
         NBTItem nbtItem = new NBTItem(item);
-        if (nbtItem.hasKey(NbtUtils.NBT_DECK_NUMBER))
-            return nbtItem.getInteger(NbtUtils.NBT_DECK_NUMBER);
+        if(NbtUtils.Deck.isDeck(nbtItem))
+            return NbtUtils.Deck.getDeckNumber(nbtItem);
 
         String[] nameSplit = item.getItemMeta().getDisplayName().split("#");
         return Integer.parseInt(nameSplit[1]);

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/managers/TradingDeckManager.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/managers/TradingDeckManager.java
@@ -164,7 +164,6 @@ public class TradingDeckManager implements DeckManager {
 
     @NotNull
     @Override
-    //todo nbtcompound
     public ItemStack getNbtItem(@NotNull final Player player, final int deckNumber) {
         NBTItem nbtItem = new NBTItem(createDeckItem(player, deckNumber));
         NBTCompound nbtCompound = nbtItem.getOrCreateCompound(NbtUtils.NBT_TRADING_CARDS_COMPOUND);

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/remote/sql/MariaDbConnectionFactory.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/remote/sql/MariaDbConnectionFactory.java
@@ -30,7 +30,7 @@ public class MariaDbConnectionFactory extends HikariConnectionFactory {
     }
 
     @Override
-    protected void overrideProperties(final @NotNull @NotNull Map<String, String> properties) {
+    protected void overrideProperties(final @NotNull Map<String, String> properties) {
         //don't override anything
     }
 }

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/utils/CardUtil.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/utils/CardUtil.java
@@ -51,7 +51,7 @@ public class CardUtil {
      */
     public static void dropItem(final @NotNull Player player, final ItemStack item) {
         NBTItem nbtItem = new NBTItem(item);
-        final String debugItem = "name:" + nbtItem.getString(NbtUtils.NBT_CARD_NAME) + " rarity:" + nbtItem.getString(NbtUtils.NBT_RARITY);
+        final String debugItem = "name:" + nbtItem.getString(NbtUtils.Legacy.NBT_CARD_NAME) + " rarity:" + nbtItem.getString(NbtUtils.Legacy.NBT_RARITY);
         if (player.getInventory().firstEmpty() != -1) {
             player.getInventory().addItem(item);
             plugin.debug(CardUtil.class, "Added item " + debugItem + " to " + player.getName());
@@ -86,7 +86,7 @@ public class CardUtil {
     }
 
     public static boolean isCard(final @NotNull NBTItem nbtItem) {
-        return nbtItem.getBoolean(NbtUtils.NBT_IS_CARD);
+        return NbtUtils.Card.isCard(nbtItem);
     }
 
     private static void broadcastPrefixedMessage(final String message) {


### PR DESCRIPTION
Changes to using "trading_cards" compound. Instead of directly writing nbt tags to the items.
This will prevent possible conflicts in the future with other plugins.
CustomModelData will not be written to the item tags if it is set to 0.

Created legacy checks to preserve items from previous version.