### PR TITLE
Improves the way we handle nbt tags

### DIFF
--- a/tradingcards-api/src/main/java/net/tinetwork/tradingcards/api/card/Card.java
+++ b/tradingcards-api/src/main/java/net/tinetwork/tradingcards/api/card/Card.java
@@ -182,7 +182,7 @@ public abstract class Card<T> {
 
     public NBTItem buildNBTItem(boolean shiny) {
         NBTItem nbtItem = new NBTItem(buildItem(shiny));
-        NBTCompound nbtCompound = nbtItem.getOrCreateCompound(NbtUtils.NBT_TRADING_CARDS_COMPOUND);
+        NBTCompound nbtCompound = nbtItem.getOrCreateCompound(NbtUtils.TC_COMPOUND);
         nbtCompound.setString(NbtUtils.TC_CARD_ID, cardId);
         nbtCompound.setString(NbtUtils.TC_CARD_RARITY, rarity.getId());
         nbtCompound.setBoolean(NbtUtils.TC_CARD_SHINY, shiny);

--- a/tradingcards-api/src/main/java/net/tinetwork/tradingcards/api/card/Card.java
+++ b/tradingcards-api/src/main/java/net/tinetwork/tradingcards/api/card/Card.java
@@ -10,7 +10,7 @@ import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
-public abstract class Card<T>{
+public abstract class Card<T> {
     private final String cardId;
 
     private Material material;
@@ -41,6 +41,7 @@ public abstract class Card<T>{
 
     /**
      * Set if a card is shiny
+     *
      * @param isShiny isShiny
      * @return if the card is shiny
      */
@@ -62,13 +63,14 @@ public abstract class Card<T>{
     }
 
     public String getDisplayName() {
-        if(this.cardMeta.getDisplayName() == null || this.cardMeta.getDisplayName().isEmpty())
-            return cardId.replace("_"," ");
+        if (this.cardMeta.getDisplayName() == null || this.cardMeta.getDisplayName().isEmpty())
+            return cardId.replace("_", " ");
         return this.cardMeta.getDisplayName();
     }
 
     /**
      * Set custom model nbt
+     *
      * @param data custom model nbt
      * @return Builder
      */
@@ -88,38 +90,38 @@ public abstract class Card<T>{
         return this;
     }
 
-    public Card<T>  about(String about) {
+    public Card<T> about(String about) {
         this.cardMeta.setAbout(about);
         return this;
     }
 
-    public Card<T>  type(DropType dropType) {
+    public Card<T> type(DropType dropType) {
         this.type = dropType;
         return this;
     }
 
-    public Card<T>  info(String info) {
+    public Card<T> info(String info) {
         this.cardMeta.setInfo(info);
         return this;
     }
 
 
-    public Card<T>  buyPrice(double buyPrice) {
+    public Card<T> buyPrice(double buyPrice) {
         this.cardMeta.setBuyPrice(buyPrice);
         return this;
     }
 
-    public Card<T>  sellPrice(double sellPrice) {
+    public Card<T> sellPrice(double sellPrice) {
         this.cardMeta.setSellPrice(sellPrice);
         return this;
     }
 
-    public Card<T>  rarity(Rarity rarity) {
+    public Card<T> rarity(Rarity rarity) {
         this.rarity = rarity;
         return this;
     }
 
-    public Card<T>  isPlayerCard(boolean isPlayerCard) {
+    public Card<T> isPlayerCard(boolean isPlayerCard) {
         this.cardMeta.setPlayerCard(isPlayerCard);
         return this;
     }
@@ -181,13 +183,12 @@ public abstract class Card<T>{
     public NBTItem buildNBTItem(boolean shiny) {
         NBTItem nbtItem = new NBTItem(buildItem(shiny));
         NBTCompound nbtCompound = nbtItem.getOrCreateCompound(NbtUtils.NBT_TRADING_CARDS_COMPOUND);
-        nbtCompound.setString(NbtUtils.Legacy.NBT_CARD_NAME, cardId);
-        nbtCompound.setString(NbtUtils.Legacy.NBT_RARITY,rarity.getId());
-        nbtCompound.setBoolean(NbtUtils.Legacy.NBT_IS_CARD, true);
-        nbtCompound.setBoolean(NbtUtils.Legacy.NBT_CARD_SHINY, shiny);
-        nbtCompound.setString(NbtUtils.Legacy.NBT_CARD_SERIES,series.getId());
+        nbtCompound.setString(NbtUtils.TC_CARD_ID, cardId);
+        nbtCompound.setString(NbtUtils.TC_CARD_RARITY, rarity.getId());
+        nbtCompound.setBoolean(NbtUtils.TC_CARD_SHINY, shiny);
+        nbtCompound.setString(NbtUtils.TC_CARD_SERIES, series.getId());
 
-        if(getCustomModelNbt() != 0) {
+        if (getCustomModelNbt() != 0) {
             nbtItem.setInteger(NbtUtils.NBT_CARD_CUSTOM_MODEL, this.cardMeta.getCustomModelNbt());
         }
 

--- a/tradingcards-api/src/main/java/net/tinetwork/tradingcards/api/card/Card.java
+++ b/tradingcards-api/src/main/java/net/tinetwork/tradingcards/api/card/Card.java
@@ -188,7 +188,7 @@ public abstract class Card<T>{
         nbtCompound.setString(NbtUtils.Legacy.NBT_CARD_SERIES,series.getId());
 
         if(getCustomModelNbt() != 0) {
-            nbtItem.setInteger(NbtUtils.Legacy.NBT_CARD_CUSTOM_MODEL, this.cardMeta.getCustomModelNbt());
+            nbtItem.setInteger(NbtUtils.NBT_CARD_CUSTOM_MODEL, this.cardMeta.getCustomModelNbt());
         }
 
         return nbtItem;

--- a/tradingcards-api/src/main/java/net/tinetwork/tradingcards/api/utils/NbtUtils.java
+++ b/tradingcards-api/src/main/java/net/tinetwork/tradingcards/api/utils/NbtUtils.java
@@ -13,7 +13,18 @@ import java.util.Objects;
  properly anymore.!!
  */
 public class NbtUtils {
-    public static final String NBT_TRADING_CARDS_COMPOUND = "trading_cards";
+    public static final String NBT_TRADING_CARDS_COMPOUND = "trading-cards";
+    public static final String NBT_CARD_CUSTOM_MODEL = "CustomModelData";
+
+    // Deck Stuff
+    public static final String TC_DECK_NUMBER = "tc-deck-number";
+    // Card Stuff
+    public static final String TC_CARD_ID = "tc-card-id";
+    public static final String TC_CARD_RARITY = "tc-card-rarity";
+    public static final String TC_CARD_SHINY = "tc-card-shiny";
+    public static final String TC_CARD_SERIES = "tc-card-series";
+
+    public static final String TC_PACK_ID = "tc-pack-id";
 
     private NbtUtils() {
         throw new UnsupportedOperationException();
@@ -22,15 +33,15 @@ public class NbtUtils {
     public static class Legacy {
         //Deck Item
         public static final String NBT_DECK_NUMBER = "deckNumber";
-        public static final String NBT_IS_DECK = "isDeck";
+        public static final String NBT_IS_DECK = "isDeck"; //we should consider not having this at all
 
         //Card Item
-        public static final String NBT_IS_CARD = "isCard";
+        public static final String NBT_IS_CARD = "isCard"; //we should consider not having this at all
         public static final String NBT_CARD_NAME = "name";
         public static final String NBT_RARITY = "rarity";
         public static final String NBT_CARD_SHINY = "shiny";
         public static final String NBT_CARD_SERIES = "series";
-        public static final String NBT_CARD_CUSTOM_MODEL = "CustomModelData";
+
 
         //Pack Item
         public static final String NBT_PACK = "pack";
@@ -53,17 +64,18 @@ public class NbtUtils {
         private Deck() {
             throw new UnsupportedOperationException();
         }
+
         public static int getDeckNumber(final @NotNull NBTItem item) {
-            if(isLegacy(item)) {
+            if (isLegacy(item)) {
                 return item.getInteger(Legacy.NBT_DECK_NUMBER);
             }
-            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).getInteger(Legacy.NBT_DECK_NUMBER);
+            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).getInteger(TC_DECK_NUMBER);
         }
 
         public static boolean isDeck(final @NotNull NBTItem item) {
-            if(isLegacy(item))
-                return item.getBoolean(Legacy.NBT_IS_DECK);
-            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).getBoolean(Legacy.NBT_IS_DECK);
+            if (isLegacy(item))
+                return item.hasKey(Legacy.NBT_IS_DECK);
+            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).hasKey(TC_DECK_NUMBER);
         }
     }
 
@@ -73,33 +85,33 @@ public class NbtUtils {
         }
 
         public static String getCardId(final @NotNull NBTItem item) {
-            if(isLegacy(item))
+            if (isLegacy(item))
                 return item.getString(Legacy.NBT_CARD_NAME);
-            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).getString(Legacy.NBT_CARD_NAME);
+            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).getString(TC_CARD_ID);
         }
 
         public static String getRarityId(final @NotNull NBTItem item) {
-            if(isLegacy(item))
+            if (isLegacy(item))
                 return item.getString(Legacy.NBT_RARITY);
-            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).getString(Legacy.NBT_RARITY);
+            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).getString(TC_CARD_RARITY);
         }
 
         public static String getSeriesId(final @NotNull NBTItem item) {
-            if(isLegacy(item))
+            if (isLegacy(item))
                 return item.getString(Legacy.NBT_CARD_SERIES);
-            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).getString(Legacy.NBT_CARD_SERIES);
+            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).getString(TC_CARD_SERIES);
         }
 
         public static boolean isShiny(final @NotNull NBTItem item) {
-            if(isLegacy(item))
+            if (isLegacy(item))
                 return item.getBoolean(Legacy.NBT_CARD_SHINY);
-            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).getBoolean(Legacy.NBT_CARD_SHINY);
+            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).getBoolean(TC_CARD_SHINY);
         }
 
         public static boolean isCard(final @NotNull NBTItem item) {
-            if(isLegacy(item))
+            if (isLegacy(item))
                 return item.getBoolean(Legacy.NBT_IS_CARD);
-            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).getBoolean(Legacy.NBT_IS_CARD);
+            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).hasKey(TC_CARD_ID);
         }
     }
 
@@ -109,19 +121,20 @@ public class NbtUtils {
         }
 
         public static String getPackId(final @NotNull NBTItem item) {
-            if(isLegacy(item))
+            if (isLegacy(item))
                 return item.getString(Legacy.NBT_PACK_ID);
-            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).getString(Legacy.NBT_PACK_ID);
+            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).getString(TC_PACK_ID);
         }
+
         public static boolean isPack(final @NotNull NBTItem item) {
-            if(isLegacy(item))
+            if (isLegacy(item))
                 return item.getBoolean(Legacy.NBT_PACK);
-            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).getBoolean(Legacy.NBT_PACK);
+            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).hasKey(TC_PACK_ID);
         }
     }
 
 
     public static boolean isLegacy(final @NotNull NBTItem item) {
-        return item.getCompound(NBT_TRADING_CARDS_COMPOUND) == null;
+        return !item.hasKey(NBT_TRADING_CARDS_COMPOUND);
     }
 }

--- a/tradingcards-api/src/main/java/net/tinetwork/tradingcards/api/utils/NbtUtils.java
+++ b/tradingcards-api/src/main/java/net/tinetwork/tradingcards/api/utils/NbtUtils.java
@@ -13,8 +13,8 @@ import java.util.Objects;
  properly anymore.!!
  */
 public class NbtUtils {
-    public static final String NBT_TRADING_CARDS_COMPOUND = "trading-cards";
     public static final String NBT_CARD_CUSTOM_MODEL = "CustomModelData";
+    public static final String TC_COMPOUND = "trading-cards";
 
     // Deck Stuff
     public static final String TC_DECK_NUMBER = "tc-deck-number";
@@ -69,13 +69,13 @@ public class NbtUtils {
             if (isLegacy(item)) {
                 return item.getInteger(Legacy.NBT_DECK_NUMBER);
             }
-            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).getInteger(TC_DECK_NUMBER);
+            return item.getCompound(TC_COMPOUND).getInteger(TC_DECK_NUMBER);
         }
 
         public static boolean isDeck(final @NotNull NBTItem item) {
             if (isLegacy(item))
                 return item.hasKey(Legacy.NBT_IS_DECK);
-            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).hasKey(TC_DECK_NUMBER);
+            return item.getCompound(TC_COMPOUND).hasKey(TC_DECK_NUMBER);
         }
     }
 
@@ -87,31 +87,31 @@ public class NbtUtils {
         public static String getCardId(final @NotNull NBTItem item) {
             if (isLegacy(item))
                 return item.getString(Legacy.NBT_CARD_NAME);
-            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).getString(TC_CARD_ID);
+            return item.getCompound(TC_COMPOUND).getString(TC_CARD_ID);
         }
 
         public static String getRarityId(final @NotNull NBTItem item) {
             if (isLegacy(item))
                 return item.getString(Legacy.NBT_RARITY);
-            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).getString(TC_CARD_RARITY);
+            return item.getCompound(TC_COMPOUND).getString(TC_CARD_RARITY);
         }
 
         public static String getSeriesId(final @NotNull NBTItem item) {
             if (isLegacy(item))
                 return item.getString(Legacy.NBT_CARD_SERIES);
-            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).getString(TC_CARD_SERIES);
+            return item.getCompound(TC_COMPOUND).getString(TC_CARD_SERIES);
         }
 
         public static boolean isShiny(final @NotNull NBTItem item) {
             if (isLegacy(item))
                 return item.getBoolean(Legacy.NBT_CARD_SHINY);
-            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).getBoolean(TC_CARD_SHINY);
+            return item.getCompound(TC_COMPOUND).getBoolean(TC_CARD_SHINY);
         }
 
         public static boolean isCard(final @NotNull NBTItem item) {
             if (isLegacy(item))
                 return item.getBoolean(Legacy.NBT_IS_CARD);
-            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).hasKey(TC_CARD_ID);
+            return item.getCompound(TC_COMPOUND).hasKey(TC_CARD_ID);
         }
     }
 
@@ -123,18 +123,18 @@ public class NbtUtils {
         public static String getPackId(final @NotNull NBTItem item) {
             if (isLegacy(item))
                 return item.getString(Legacy.NBT_PACK_ID);
-            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).getString(TC_PACK_ID);
+            return item.getCompound(TC_COMPOUND).getString(TC_PACK_ID);
         }
 
         public static boolean isPack(final @NotNull NBTItem item) {
             if (isLegacy(item))
                 return item.getBoolean(Legacy.NBT_PACK);
-            return item.getCompound(NBT_TRADING_CARDS_COMPOUND).hasKey(TC_PACK_ID);
+            return item.getCompound(TC_COMPOUND).hasKey(TC_PACK_ID);
         }
     }
 
 
     public static boolean isLegacy(final @NotNull NBTItem item) {
-        return !item.hasKey(NBT_TRADING_CARDS_COMPOUND);
+        return !item.hasKey(TC_COMPOUND);
     }
 }

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/managers/BoosterPackManager.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/managers/BoosterPackManager.java
@@ -122,9 +122,8 @@ public class BoosterPackManager extends Manager<String, Pack> implements PackMan
         itemPackMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
         itemPack.setItemMeta(itemPackMeta);
         NBTItem nbtItem = new NBTItem(itemPack);
-        NBTCompound compound = nbtItem.getOrCreateCompound(NbtUtils.NBT_TRADING_CARDS_COMPOUND);
-        compound.setString(NbtUtils.Legacy.NBT_PACK_ID, pack.id());
-        compound.setBoolean(NbtUtils.Legacy.NBT_PACK,true);
+        NBTCompound compound = nbtItem.getOrCreateCompound(NbtUtils.TC_COMPOUND);
+        compound.setString(NbtUtils.TC_PACK_ID, pack.id());
         return nbtItem.getItem();
     }
 

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/managers/TradingDeckManager.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/managers/TradingDeckManager.java
@@ -166,9 +166,8 @@ public class TradingDeckManager implements DeckManager {
     @Override
     public ItemStack getNbtItem(@NotNull final Player player, final int deckNumber) {
         NBTItem nbtItem = new NBTItem(createDeckItem(player, deckNumber));
-        NBTCompound nbtCompound = nbtItem.getOrCreateCompound(NbtUtils.NBT_TRADING_CARDS_COMPOUND);
-        nbtCompound.setBoolean(NbtUtils.Legacy.NBT_IS_DECK, true);
-        nbtCompound.setInteger(NbtUtils.Legacy.NBT_DECK_NUMBER, deckNumber);
+        NBTCompound nbtCompound = nbtItem.getOrCreateCompound(NbtUtils.TC_COMPOUND);
+        nbtCompound.setInteger(NbtUtils.TC_DECK_NUMBER, deckNumber);
         return nbtItem.getItem();
     }
 

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/utils/CardUtil.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/utils/CardUtil.java
@@ -51,7 +51,7 @@ public class CardUtil {
      */
     public static void dropItem(final @NotNull Player player, final ItemStack item) {
         NBTItem nbtItem = new NBTItem(item);
-        final String debugItem = "name:" + nbtItem.getString(NbtUtils.Legacy.NBT_CARD_NAME) + " rarity:" + nbtItem.getString(NbtUtils.Legacy.NBT_RARITY);
+        final String debugItem = "name:" + nbtItem.getString(NbtUtils.TC_CARD_ID) + " rarity:" + nbtItem.getString(NbtUtils.TC_CARD_RARITY);
         if (player.getInventory().firstEmpty() != -1) {
             player.getInventory().addItem(item);
             plugin.debug(CardUtil.class, "Added item " + debugItem + " to " + player.getName());


### PR DESCRIPTION
Previously we committed a change that sets a compound. This PR will outline the total changes from before that change to now.

The new nbt tags:
```
  tc-card-id 
  tc-card-rarity 
  tc-card-series 
  tc-card-shiny 
  tc-deck-number
  tc-pack-id
```
## Current NBT Format:

### Card
```
item {
  isCard = true
  name = zombie
  rarity = common
  series = default
}
```

### Deck
```
item {
  isDeck = true
  deckNumber = 1
}
```
### Pack
```
item {
  pack = true
  packId = starter-pack
}
```

## New NBT Format:

### Card
```
item {
  trading-cards {
    tc-card-id = zombie
    tc-card-rarity = common
    tc-card-series = default
    tc-card-shiny = true
  }
}
```
### Deck
```
item {
  trading-cards {
    tc-deck-number = 1
  }
}
```

### Pack
```
item {
  trading-cards {
    tc-pack-id = starter-pack
  }
}