### PR TITLE
Adds an info command

### DIFF
--- a/tradingcards-api/src/main/java/net/tinetwork/tradingcards/api/model/Pack.java
+++ b/tradingcards-api/src/main/java/net/tinetwork/tradingcards/api/model/Pack.java
@@ -49,10 +49,9 @@ public class Pack {
         this.currencyId = currencyId;
     }
 
-    public String id() {
+    public String getId() {
         return id;
     }
-
 
     public void setDisplayName(final String displayName) {
         this.displayName = displayName;

--- a/tradingcards-api/src/main/java/net/tinetwork/tradingcards/api/model/Rarity.java
+++ b/tradingcards-api/src/main/java/net/tinetwork/tradingcards/api/model/Rarity.java
@@ -71,28 +71,12 @@ public final class Rarity {
                 '}';
     }
 
-    public String name() {
-        return id;
-    }
-
-    public String displayName() {
-        return displayName;
-    }
-
-    public String defaultColor() {
-        return defaultColor;
-    }
-
-    public double buyPrice() {
+    public double getBuyPrice() {
         return buyPrice;
     }
 
-    public double sellPrice() {
+    public double getSellPrice() {
         return sellPrice;
-    }
-
-    public List<String> rewards() {
-        return rewards;
     }
 
     @Override

--- a/tradingcards-plugin/internal-messages/internal-messages.json
+++ b/tradingcards-plugin/internal-messages/internal-messages.json
@@ -63,42 +63,42 @@
   },
   "info-command": {
     "card-format": [
-      "Id: %s",
-      "Series: %s",
-      "Rarity: %s",
-      "Display Name: %s",
-      "Buy Price: %.2f",
-      "Sell Price: %.2f",
-      "Currency Id: %s",
-      "About: %s",
-      "Info: %s"
+      "&bCard:&f %s",
+      "&bSeries:&f %s",
+      "&bRarity:&f %s",
+      "&bDisplay Name:&f %s",
+      "&bBuy Price:&f %.2f",
+      "&bSell Price:&f %.2f",
+      "&bCurrency:&f %s",
+      "&bAbout:&f %s",
+      "&bInfo:&f %s"
     ],
     "pack-format": [
-      "Id: %s",
-      "Display Name: %s",
-      "Content: %s",
-      "Currency Id: %s",
-      "Buy Price: %s"
+      "&bPack:&f %s",
+      "&bDisplay Name:&f %s",
+      "&bContent:&f %s",
+      "&bCurrency:&f %s",
+      "&bBuy Price:&f %s"
     ],
     "type-format": [
-      "Id: %s",
-      "Display Name: %s",
-      "Mob Type: %s"
+      "&bType:&f %s",
+      "&bDisplay Name:&f %s",
+      "&bMob Type:&f %s"
     ],
     "series-format": [
-      "Id: %s",
-      "Display Name: %s",
-      "Mode: %s",
-      "Colors: %s"
+      "&bSeries:&f %s",
+      "&bDisplay Name:&f '%s'",
+      "&bMode:&f %s",
+      "&bColors:&f %s"
     ],
     "rarity-format": [
-      "Id: %s",
-      "Display Name: %s",
-      "Default Color: %s",
-      "Buy Price: %.2f",
-      "Sell Price: %.2f",
-      "Currency Id: %s",
-      "Rewards: %s"
+      "&bRarity:&f %s",
+      "&bDisplay Name:&f '%s'",
+      "&bDefault Color:&f %s",
+      "&bBuy Price:&f %.2f",
+      "&bSell Price:&f %.2f",
+      "&bCurrency Id:&f %s",
+      "&bRewards:&f %s"
     ],
     "mob-format": "Entity %s is %s"
   },

--- a/tradingcards-plugin/internal-messages/internal-messages.json
+++ b/tradingcards-plugin/internal-messages/internal-messages.json
@@ -61,5 +61,46 @@
     "cannot-sell-shiny": "Cannot sell shiny card.",
     "sold-card": "You have sold %dx%s for %.2f"
   },
+  "info-command": {
+    "card-format": [
+      "Id: %s",
+      "Series: %s",
+      "Rarity: %s",
+      "Display Name: %s",
+      "Buy Price: %.2f",
+      "Sell Price: %.2f",
+      "Currency Id: %s",
+      "About: %s",
+      "Info: %s"
+    ],
+    "pack-format": [
+      "Id: %s",
+      "Display Name: %s",
+      "Content: %s",
+      "Currency Id: %s",
+      "Buy Price: %s"
+    ],
+    "type-format": [
+      "Id: %s",
+      "Display Name: %s",
+      "Mob Type: %s"
+    ],
+    "series-format": [
+      "Id: %s",
+      "Display Name: %s",
+      "Mode: %s",
+      "Colors: %s"
+    ],
+    "rarity-format": [
+      "Id: %s",
+      "Display Name: %s",
+      "Default Color: %s",
+      "Buy Price: %.2f",
+      "Sell Price: %.2f",
+      "Currency Id: %s",
+      "Rewards: %s"
+    ],
+    "mob-format": "Entity %s is %s"
+  },
   "cannot-have-more-than-a-stack": "Cannot have more than a stack of this card per deck."
 }

--- a/tradingcards-plugin/internal-messages/permissions.json
+++ b/tradingcards-plugin/internal-messages/permissions.json
@@ -42,5 +42,12 @@
   "edit-rarity": "cards.edit.rarity",
   "edit-series": "cards.edit.series",
   "edit-custom-type": "cards.edit.customtype",
-  "edit-pack": "cards.edit.pack"
+  "edit-pack": "cards.edit.pack",
+  "info": "cards.info",
+  "info-card":"cards.info.card",
+  "info-rarity": "cards.info.rarity",
+  "info-type": "cards.info.type",
+  "info-series": "cards.info.series",
+  "info-mob": "cards.info.mob",
+  "info-pack": "cards.info.pack"
 }

--- a/tradingcards-plugin/pom.xml
+++ b/tradingcards-plugin/pom.xml
@@ -20,7 +20,7 @@
         <jacoco.version>0.8.8</jacoco.version>
         <maven.shade.version>3.3.0</maven.shade.version>
         <maven.surefire.version>3.0.0-M7</maven.surefire.version>
-        <messages.plugin.version>1.2.2</messages.plugin.version>
+        <messages.plugin.version>1.2.3</messages.plugin.version>
         <formatter.version>2.19.0</formatter.version>
 
         <!-- Bukkit Libs -->

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/TradingCards.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/TradingCards.java
@@ -22,6 +22,7 @@ import net.tinetwork.tradingcards.tradingcardsplugin.commands.DebugCommands;
 import net.tinetwork.tradingcards.tradingcardsplugin.commands.DeckCommand;
 import net.tinetwork.tradingcards.tradingcardsplugin.commands.EditCommand;
 import net.tinetwork.tradingcards.tradingcardsplugin.commands.GiveCommands;
+import net.tinetwork.tradingcards.tradingcardsplugin.commands.InfoCommand;
 import net.tinetwork.tradingcards.tradingcardsplugin.commands.ListCommand;
 import net.tinetwork.tradingcards.tradingcardsplugin.commands.MigrateCommand;
 import net.tinetwork.tradingcards.tradingcardsplugin.commands.SellCommand;
@@ -337,6 +338,7 @@ public class TradingCards extends TradingCardsPlugin<TradingCard> {
         commandManager.registerCommand(this.migrateCommand);
         commandManager.registerCommand(new SellCommand(this));
         commandManager.registerCommand(new DeckCommand(this));
+        commandManager.registerCommand(new InfoCommand(this));
         commandManager.enableUnstableAPI("help");
         commandManager.enableUnstableAPI("brigadier");
     }

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/EditCommand.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/EditCommand.java
@@ -328,11 +328,11 @@ public class EditCommand extends BaseCommand {
         //set edit.toString() to value for id
         private void sendSetTypes(final CommandSender sender, final String id, final @NotNull Edit edit, final String value) {
             if (edit instanceof EditRarity editRarity && editRarity == EditRarity.DEFAULT_COLOR) {
-                String partialFormat = String.format("&7Set &b%s &7to &b{value} &7for &b%s", edit, id);
+                String partialFormat = "&7Set &b%s &7to &b{value} &7for &b%s".formatted(edit, id);
                 sender.sendMessage(ChatUtil.color(plugin.prefixed(partialFormat)).replace("{value}", value));
                 return;
             }
-            ChatUtil.sendPrefixedMessage(sender, String.format("&7Set &b%s &7to &b%s &7for &b%s", edit, value, id));
+            ChatUtil.sendPrefixedMessage(sender, "&7Set &b%s &7to &b%s &7for &b%s".formatted(edit, value, id));
         }
     }
 

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/InfoCommand.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/InfoCommand.java
@@ -1,0 +1,119 @@
+package net.tinetwork.tradingcards.tradingcardsplugin.commands;
+
+import co.aikar.commands.BaseCommand;
+import co.aikar.commands.annotation.CommandAlias;
+import co.aikar.commands.annotation.CommandCompletion;
+import co.aikar.commands.annotation.Description;
+import co.aikar.commands.annotation.Subcommand;
+import net.tinetwork.tradingcards.api.model.DropType;
+import net.tinetwork.tradingcards.api.model.Pack;
+import net.tinetwork.tradingcards.api.model.Rarity;
+import net.tinetwork.tradingcards.api.model.Series;
+import net.tinetwork.tradingcards.tradingcardsplugin.TradingCards;
+import net.tinetwork.tradingcards.tradingcardsplugin.card.TradingCard;
+import net.tinetwork.tradingcards.tradingcardsplugin.utils.ChatUtil;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+
+/**
+ * @author sarhatabaot
+ */
+@CommandAlias("cards")
+public class InfoCommand extends BaseCommand {
+    private final TradingCards plugin;
+
+    public InfoCommand(final TradingCards plugin) {
+        this.plugin = plugin;
+    }
+
+    @Subcommand("info")
+    public class InfoSubCommand extends BaseCommand {
+
+        @Subcommand("card")
+        @CommandCompletion("@rarities @series @cards")
+        public void onCard(final Player sender, final Rarity rarity, final Series series, final String cardId) {
+            if (!plugin.getCardManager().containsCard(cardId, rarity.getId(), series.getId())) {
+                sender.sendMessage(plugin.getMessagesConfig().noCard());
+                return;
+            }
+
+            TradingCard card = plugin.getCardManager().getCard(cardId, rarity.getId(), series.getId());
+
+            ChatUtil.sendPrefixedMessages(sender,
+                    "Id: %s".formatted(card.getCardId()),
+                    "Series: %s".formatted(card.getSeries().getId()),
+                    "Rarity: %s".formatted(card.getRarity().getId()),
+                    "Display Name: %s".formatted(card.getDisplayName()),
+                    "Buy Price: %.2f".formatted(card.getBuyPrice()),
+                    "Sell Price: %.2f".formatted(card.getSellPrice()),
+                    "Currency Id: %s".formatted(card.getCurrencyId()),
+                    "About: %s".formatted(card.getAbout()),
+                    "Info: %s".formatted(card.getInfo()));
+        }
+
+        @Subcommand("pack")
+        @CommandCompletion("@packs")
+        public void onPack(final Player sender, final String packId) {
+            if(!plugin.getPackManager().containsPack(packId)) {
+                sender.sendMessage(plugin.getMessagesConfig().noBoosterPack());
+                return;
+            }
+
+            final Pack pack = plugin.getPackManager().getPack(packId);
+            ChatUtil.sendPrefixedMessages(sender,
+                    "Id: %s".formatted(pack.getId()),
+                    "Display Name: %s".formatted(pack.getDisplayName()),
+                    "Content: %s".formatted(pack.getPackEntryList().stream().map(Pack.PackEntry::toString).toList()),
+                    "Currency Id: %s".formatted(pack.getCurrencyId()),
+                    "Buy Price: %s".formatted(pack.getBuyPrice())
+                    );
+        }
+
+        @Subcommand("type")
+        @CommandCompletion("@all-types")
+        public void onType(final Player sender, final String typeId) {
+            if(!plugin.getDropTypeManager().containsType(typeId)) {
+                ChatUtil.sendPrefixedMessage(sender,"No type %s".formatted(typeId));
+                return;
+            }
+
+            DropType type = plugin.getDropTypeManager().getType(typeId);
+            ChatUtil.sendPrefixedMessages(sender,
+                    "Id: %s".formatted(type.getId()),
+                    "Display Name: %s".formatted(type.getDisplayName()),
+                    "Type: %s".formatted(type.getType()));
+        }
+
+        @Subcommand("series")
+        @CommandCompletion("@series")
+        public void onSeries(final Player sender, final Series series) {
+            ChatUtil.sendPrefixedMessages(sender,
+                    "Id: %s".formatted(series.getId()),
+                    "Display Name: %s".formatted(series.getDisplayName()),
+                    "Mode: %s".formatted(series.getMode()),
+                    "Colors: \n" +
+                            "%s".formatted(series.getColorSeries().toString()));
+        }
+
+        @Subcommand("rarity")
+        @CommandCompletion("@rarities")
+        public void onRarity(final Player sender, final Rarity rarity) {
+            ChatUtil.sendPrefixedMessages(sender,
+                    "Id: %s".formatted(rarity.getId()),
+                    "Display Name: %s".formatted(rarity.getDisplayName()),
+                    "Default Color: %s".formatted(rarity.getDefaultColor()),
+                    "Buy Price: %.2f".formatted(rarity.getBuyPrice()),
+                    "Sell Price: %.2f".formatted(rarity.getSellPrice()),
+                    "Currency Id: %s".formatted("")/*todo*/,
+                    "Rewards:\n" +
+                            "%s".formatted(rarity.getRewards()));
+        }
+
+        @Subcommand("mob")
+        @Description("Display the mob group for this entity.")
+        public void onMobInfo(final Player sender, final EntityType entityType) {
+            final DropType dropType = plugin.getDropTypeManager().getMobType(entityType);
+            ChatUtil.sendPrefixedMessage(sender, "Entity %s is %s".formatted(entityType.name(), dropType.getType()));
+        }
+    }
+}

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/InfoCommand.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/InfoCommand.java
@@ -11,9 +11,11 @@ import net.tinetwork.tradingcards.api.model.Rarity;
 import net.tinetwork.tradingcards.api.model.Series;
 import net.tinetwork.tradingcards.tradingcardsplugin.TradingCards;
 import net.tinetwork.tradingcards.tradingcardsplugin.card.TradingCard;
+import net.tinetwork.tradingcards.tradingcardsplugin.messages.internal.InternalMessages;
 import net.tinetwork.tradingcards.tradingcardsplugin.utils.ChatUtil;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * @author sarhatabaot
@@ -31,7 +33,7 @@ public class InfoCommand extends BaseCommand {
 
         @Subcommand("card")
         @CommandCompletion("@rarities @series @cards")
-        public void onCard(final Player sender, final Rarity rarity, final Series series, final String cardId) {
+        public void onCard(final Player sender, final @NotNull Rarity rarity, final @NotNull Series series, final String cardId) {
             if (!plugin.getCardManager().containsCard(cardId, rarity.getId(), series.getId())) {
                 sender.sendMessage(plugin.getMessagesConfig().noCard());
                 return;
@@ -40,15 +42,9 @@ public class InfoCommand extends BaseCommand {
             TradingCard card = plugin.getCardManager().getCard(cardId, rarity.getId(), series.getId());
 
             ChatUtil.sendPrefixedMessages(sender,
-                    "Id: %s".formatted(card.getCardId()),
-                    "Series: %s".formatted(card.getSeries().getId()),
-                    "Rarity: %s".formatted(card.getRarity().getId()),
-                    "Display Name: %s".formatted(card.getDisplayName()),
-                    "Buy Price: %.2f".formatted(card.getBuyPrice()),
-                    "Sell Price: %.2f".formatted(card.getSellPrice()),
-                    "Currency Id: %s".formatted(card.getCurrencyId()),
-                    "About: %s".formatted(card.getAbout()),
-                    "Info: %s".formatted(card.getInfo()));
+                    InternalMessages.InfoCommand.CARD_FORMAT,
+                    card.getCardId(),card.getSeries().getId(),card.getRarity().getId(),card.getDisplayName(),
+                    card.getBuyPrice(),card.getSellPrice(),card.getCurrencyId(),card.getAbout(),card.getInfo());
         }
 
         @Subcommand("pack")
@@ -61,12 +57,10 @@ public class InfoCommand extends BaseCommand {
 
             final Pack pack = plugin.getPackManager().getPack(packId);
             ChatUtil.sendPrefixedMessages(sender,
-                    "Id: %s".formatted(pack.getId()),
-                    "Display Name: %s".formatted(pack.getDisplayName()),
-                    "Content: %s".formatted(pack.getPackEntryList().stream().map(Pack.PackEntry::toString).toList()),
-                    "Currency Id: %s".formatted(pack.getCurrencyId()),
-                    "Buy Price: %s".formatted(pack.getBuyPrice())
-                    );
+                    InternalMessages.InfoCommand.PACK_FORMAT,
+                    pack.getId(), pack.getDisplayName(),
+                    pack.getPackEntryList().stream().map(Pack.PackEntry::toString).toList(),
+                    pack.getCurrencyId(), pack.getBuyPrice());
         }
 
         @Subcommand("type")
@@ -79,41 +73,33 @@ public class InfoCommand extends BaseCommand {
 
             DropType type = plugin.getDropTypeManager().getType(typeId);
             ChatUtil.sendPrefixedMessages(sender,
-                    "Id: %s".formatted(type.getId()),
-                    "Display Name: %s".formatted(type.getDisplayName()),
-                    "Type: %s".formatted(type.getType()));
+                    InternalMessages.InfoCommand.TYPE_FORMAT,
+                    type.getId(),type.getDisplayName(),type.getType());
         }
 
         @Subcommand("series")
         @CommandCompletion("@series")
-        public void onSeries(final Player sender, final Series series) {
+        public void onSeries(final Player sender, final @NotNull Series series) {
             ChatUtil.sendPrefixedMessages(sender,
-                    "Id: %s".formatted(series.getId()),
-                    "Display Name: %s".formatted(series.getDisplayName()),
-                    "Mode: %s".formatted(series.getMode()),
-                    "Colors: \n" +
-                            "%s".formatted(series.getColorSeries().toString()));
+                    InternalMessages.InfoCommand.SERIES_FORMAT,
+                    series.getId(), series.getDisplayName(), series.getMode(),
+                    series.getColorSeries().toString());
         }
 
         @Subcommand("rarity")
         @CommandCompletion("@rarities")
-        public void onRarity(final Player sender, final Rarity rarity) {
+        public void onRarity(final Player sender, final @NotNull Rarity rarity) {
             ChatUtil.sendPrefixedMessages(sender,
-                    "Id: %s".formatted(rarity.getId()),
-                    "Display Name: %s".formatted(rarity.getDisplayName()),
-                    "Default Color: %s".formatted(rarity.getDefaultColor()),
-                    "Buy Price: %.2f".formatted(rarity.getBuyPrice()),
-                    "Sell Price: %.2f".formatted(rarity.getSellPrice()),
-                    "Currency Id: %s".formatted("")/*todo*/,
-                    "Rewards:\n" +
-                            "%s".formatted(rarity.getRewards()));
+                    InternalMessages.InfoCommand.RARITY_FORMAT,
+                    rarity.getId(),rarity.getDisplayName(), rarity.getDefaultColor(),
+                    rarity.getBuyPrice(), rarity.getSellPrice(), "" /*todo*/, rarity.getRewards());
         }
 
         @Subcommand("mob")
         @Description("Display the mob group for this entity.")
         public void onMobInfo(final Player sender, final EntityType entityType) {
             final DropType dropType = plugin.getDropTypeManager().getMobType(entityType);
-            ChatUtil.sendPrefixedMessage(sender, "Entity %s is %s".formatted(entityType.name(), dropType.getType()));
+            ChatUtil.sendPrefixedMessage(sender, InternalMessages.InfoCommand.MOB_FORMAT.formatted(entityType.name(), dropType.getType()));
         }
     }
 }

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/InfoCommand.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/InfoCommand.java
@@ -3,6 +3,7 @@ package net.tinetwork.tradingcards.tradingcardsplugin.commands;
 import co.aikar.commands.BaseCommand;
 import co.aikar.commands.annotation.CommandAlias;
 import co.aikar.commands.annotation.CommandCompletion;
+import co.aikar.commands.annotation.CommandPermission;
 import co.aikar.commands.annotation.Description;
 import co.aikar.commands.annotation.Subcommand;
 import net.tinetwork.tradingcards.api.model.DropType;
@@ -12,7 +13,9 @@ import net.tinetwork.tradingcards.api.model.Series;
 import net.tinetwork.tradingcards.tradingcardsplugin.TradingCards;
 import net.tinetwork.tradingcards.tradingcardsplugin.card.TradingCard;
 import net.tinetwork.tradingcards.tradingcardsplugin.messages.internal.InternalMessages;
+import net.tinetwork.tradingcards.tradingcardsplugin.messages.internal.Permissions;
 import net.tinetwork.tradingcards.tradingcardsplugin.utils.ChatUtil;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -21,6 +24,7 @@ import org.jetbrains.annotations.NotNull;
  * @author sarhatabaot
  */
 @CommandAlias("cards")
+
 public class InfoCommand extends BaseCommand {
     private final TradingCards plugin;
 
@@ -29,11 +33,13 @@ public class InfoCommand extends BaseCommand {
     }
 
     @Subcommand("info")
+    @CommandPermission(Permissions.INFO)
     public class InfoSubCommand extends BaseCommand {
 
         @Subcommand("card")
         @CommandCompletion("@rarities @series @cards")
-        public void onCard(final Player sender, final @NotNull Rarity rarity, final @NotNull Series series, final String cardId) {
+        @CommandPermission(Permissions.INFO_CARD)
+        public void onCard(final CommandSender sender, final @NotNull Rarity rarity, final @NotNull Series series, final String cardId) {
             if (!plugin.getCardManager().containsCard(cardId, rarity.getId(), series.getId())) {
                 sender.sendMessage(plugin.getMessagesConfig().noCard());
                 return;
@@ -49,7 +55,8 @@ public class InfoCommand extends BaseCommand {
 
         @Subcommand("pack")
         @CommandCompletion("@packs")
-        public void onPack(final Player sender, final String packId) {
+        @CommandPermission(Permissions.INFO_PACK)
+        public void onPack(final CommandSender sender, final String packId) {
             if(!plugin.getPackManager().containsPack(packId)) {
                 sender.sendMessage(plugin.getMessagesConfig().noBoosterPack());
                 return;
@@ -65,7 +72,8 @@ public class InfoCommand extends BaseCommand {
 
         @Subcommand("type")
         @CommandCompletion("@all-types")
-        public void onType(final Player sender, final String typeId) {
+        @CommandPermission(Permissions.INFO_TYPE)
+        public void onType(final CommandSender sender, final String typeId) {
             if(!plugin.getDropTypeManager().containsType(typeId)) {
                 ChatUtil.sendPrefixedMessage(sender,"No type %s".formatted(typeId));
                 return;
@@ -79,7 +87,8 @@ public class InfoCommand extends BaseCommand {
 
         @Subcommand("series")
         @CommandCompletion("@series")
-        public void onSeries(final Player sender, final @NotNull Series series) {
+        @CommandPermission(Permissions.INFO_SERIES)
+        public void onSeries(final CommandSender sender, final @NotNull Series series) {
             ChatUtil.sendPrefixedMessages(sender,
                     InternalMessages.InfoCommand.SERIES_FORMAT,
                     series.getId(), series.getDisplayName(), series.getMode(),
@@ -88,7 +97,8 @@ public class InfoCommand extends BaseCommand {
 
         @Subcommand("rarity")
         @CommandCompletion("@rarities")
-        public void onRarity(final Player sender, final @NotNull Rarity rarity) {
+        @CommandPermission(Permissions.INFO_PACK)
+        public void onRarity(final CommandSender sender, final @NotNull Rarity rarity) {
             ChatUtil.sendPrefixedMessages(sender,
                     InternalMessages.InfoCommand.RARITY_FORMAT,
                     rarity.getId(),rarity.getDisplayName(), rarity.getDefaultColor(),
@@ -97,7 +107,8 @@ public class InfoCommand extends BaseCommand {
 
         @Subcommand("mob")
         @Description("Display the mob group for this entity.")
-        public void onMobInfo(final Player sender, final EntityType entityType) {
+        @CommandPermission(Permissions.INFO_MOB)
+        public void onMobInfo(final CommandSender sender, final EntityType entityType) {
             final DropType dropType = plugin.getDropTypeManager().getMobType(entityType);
             ChatUtil.sendPrefixedMessage(sender, InternalMessages.InfoCommand.MOB_FORMAT.formatted(entityType.name(), dropType.getType()));
         }

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/InfoCommand.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/InfoCommand.java
@@ -17,7 +17,6 @@ import net.tinetwork.tradingcards.tradingcardsplugin.messages.internal.Permissio
 import net.tinetwork.tradingcards.tradingcardsplugin.utils.ChatUtil;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.EntityType;
-import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 /**

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/migrate/PackMigratorBukkitRunnable.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/migrate/PackMigratorBukkitRunnable.java
@@ -30,14 +30,15 @@ public class PackMigratorBukkitRunnable extends MigratorBukkitRunnable{
     @Override
     public void onExecute() throws ConfigurateException {
         for(Pack pack: source.getPacks()) {
-            Util.logAndMessage(sender, InternalMessages.STARTED_CONVERSION_FOR.formatted(pack.id()));
-            plugin.getStorage().createPack(pack.id());
-            plugin.getStorage().editPackPrice(pack.id(),pack.getBuyPrice());
-            plugin.getStorage().editPackPermission(pack.id(),pack.getPermission());
-            plugin.getStorage().editPackDisplayName(pack.id(), pack.getDisplayName());
+            final String packId = pack.getId();
+            Util.logAndMessage(sender, InternalMessages.STARTED_CONVERSION_FOR.formatted(packId));
+            plugin.getStorage().createPack(packId);
+            plugin.getStorage().editPackPrice(packId,pack.getBuyPrice());
+            plugin.getStorage().editPackPermission(packId,pack.getPermission());
+            plugin.getStorage().editPackDisplayName(packId, pack.getDisplayName());
 
             for(final Pack.PackEntry entry:pack.getPackEntryList()){
-                plugin.getStorage().editPackContentsAdd(pack.id(),entry);
+                plugin.getStorage().editPackContentsAdd(packId,entry);
             }
         }
     }

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/migrate/RarityMigratorBukkitRunnable.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/migrate/RarityMigratorBukkitRunnable.java
@@ -24,8 +24,8 @@ public class RarityMigratorBukkitRunnable extends MigratorBukkitRunnable{
         for(final Rarity rarity: source.getRarities()) {
             Util.logAndMessage(sender, InternalMessages.STARTED_CONVERSION_FOR.formatted(rarity.getId()));
             plugin.getStorage().createRarity(rarity.getId());
-            plugin.getStorage().editRaritySellPrice(rarity.getId(),rarity.sellPrice());
-            plugin.getStorage().editRarityBuyPrice(rarity.getId(),rarity.buyPrice());
+            plugin.getStorage().editRaritySellPrice(rarity.getId(),rarity.getSellPrice());
+            plugin.getStorage().editRarityBuyPrice(rarity.getId(),rarity.getBuyPrice());
             plugin.getStorage().editRarityDefaultColor(rarity.getId(), rarity.getDefaultColor());
             plugin.getStorage().editRarityDisplayName(rarity.getId(),rarity.getDisplayName());
 

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/managers/BoosterPackManager.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/managers/BoosterPackManager.java
@@ -43,7 +43,7 @@ public class BoosterPackManager extends Manager<String, Pack> implements PackMan
 
     @Override
     public List<String> getKeys() {
-        return plugin.getStorage().getPacks().stream().map(Pack::id).toList();
+        return plugin.getStorage().getPacks().stream().map(Pack::getId).toList();
     }
 
     @Override
@@ -124,7 +124,7 @@ public class BoosterPackManager extends Manager<String, Pack> implements PackMan
         itemPack.setItemMeta(itemPackMeta);
         NBTItem nbtItem = new NBTItem(itemPack);
         NBTCompound compound = nbtItem.getOrCreateCompound(NbtUtils.TC_COMPOUND);
-        compound.setString(NbtUtils.TC_PACK_ID, pack.id());
+        compound.setString(NbtUtils.TC_PACK_ID, pack.getId());
         return nbtItem.getItem();
     }
 
@@ -150,7 +150,7 @@ public class BoosterPackManager extends Manager<String, Pack> implements PackMan
     @Override
     public boolean containsPack(final String packId) {
         for (Pack pack : getPacks()) {
-            if (pack.id().equals(packId))
+            if (pack.getId().equals(packId))
                 return true;
         }
         return false;

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/messages/internal/InternalMessages.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/messages/internal/InternalMessages.java
@@ -106,15 +106,18 @@ public final class InternalMessages {
     }
 
     public static class InfoCommand {
-        public static final String[] CARD_FORMAT = new String[] { "Id: %s", "Series: %s", "Rarity: %s",
-                "Display Name: %s", "Buy Price: %.2f", "Sell Price: %.2f", "Currency Id: %s", "About: %s", "Info: %s" };
-        public static final String[] PACK_FORMAT = new String[] { "Id: %s", "Display Name: %s", "Content: %s",
-                "Currency Id: %s", "Buy Price: %s" };
-        public static final String[] TYPE_FORMAT = new String[] { "Id: %s", "Display Name: %s", "Mob Type: %s" };
-        public static final String[] SERIES_FORMAT = new String[] { "Id: %s", "Display Name: %s", "Mode: %s",
-                "Colors: %s" };
-        public static final String[] RARITY_FORMAT = new String[] { "Id: %s", "Display Name: %s", "Default Color: %s",
-                "Buy Price: %.2f", "Sell Price: %.2f", "Currency Id: %s", "Rewards: %s" };
+        public static final String[] CARD_FORMAT = new String[] { "&bCard:&f %s", "&bSeries:&f %s", "&bRarity:&f %s",
+                "&bDisplay Name:&f %s", "&bBuy Price:&f %.2f", "&bSell Price:&f %.2f", "&bCurrency:&f %s",
+                "&bAbout:&f %s", "&bInfo:&f %s" };
+        public static final String[] PACK_FORMAT = new String[] { "&bPack:&f %s", "&bDisplay Name:&f %s",
+                "&bContent:&f %s", "&bCurrency:&f %s", "&bBuy Price:&f %s" };
+        public static final String[] TYPE_FORMAT = new String[] { "&bType:&f %s", "&bDisplay Name:&f %s",
+                "&bMob Type:&f %s" };
+        public static final String[] SERIES_FORMAT = new String[] { "&bSeries:&f %s", "&bDisplay Name:&f '%s'",
+                "&bMode:&f %s", "&bColors:&f %s" };
+        public static final String[] RARITY_FORMAT = new String[] { "&bRarity:&f %s", "&bDisplay Name:&f '%s'",
+                "&bDefault Color:&f %s", "&bBuy Price:&f %.2f", "&bSell Price:&f %.2f", "&bCurrency Id:&f %s",
+                "&bRewards:&f %s" };
         public static final String MOB_FORMAT = "Entity %s is %s";
 
         private InfoCommand() {

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/messages/internal/InternalMessages.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/messages/internal/InternalMessages.java
@@ -105,6 +105,23 @@ public final class InternalMessages {
         }
     }
 
+    public static class InfoCommand {
+        public static final String[] CARD_FORMAT = new String[] { "Id: %s", "Series: %s", "Rarity: %s",
+                "Display Name: %s", "Buy Price: %.2f", "Sell Price: %.2f", "Currency Id: %s", "About: %s", "Info: %s" };
+        public static final String[] PACK_FORMAT = new String[] { "Id: %s", "Display Name: %s", "Content: %s",
+                "Currency Id: %s", "Buy Price: %s" };
+        public static final String[] TYPE_FORMAT = new String[] { "Id: %s", "Display Name: %s", "Mob Type: %s" };
+        public static final String[] SERIES_FORMAT = new String[] { "Id: %s", "Display Name: %s", "Mode: %s",
+                "Colors: %s" };
+        public static final String[] RARITY_FORMAT = new String[] { "Id: %s", "Display Name: %s", "Default Color: %s",
+                "Buy Price: %.2f", "Sell Price: %.2f", "Currency Id: %s", "Rewards: %s" };
+        public static final String MOB_FORMAT = "Entity %s is %s";
+
+        private InfoCommand() {
+            throw new UnsupportedOperationException(InternalExceptions.UTIL_CLASS);
+        }
+    }
+
     public static final String CANNOT_HAVE_MORE_THAN_A_STACK = "Cannot have more than a stack of this card per deck.";
 
     private InternalMessages() {

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/messages/internal/Permissions.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/messages/internal/Permissions.java
@@ -45,6 +45,13 @@ public final class Permissions {
     public static final String EDIT_SERIES = "cards.edit.series";
     public static final String EDIT_CUSTOM_TYPE = "cards.edit.customtype";
     public static final String EDIT_PACK = "cards.edit.pack";
+    public static final String INFO = "cards.info";
+    public static final String INFO_CARD = "cards.info.card";
+    public static final String INFO_RARITY = "cards.info.rarity";
+    public static final String INFO_TYPE = "cards.info.type";
+    public static final String INFO_SERIES = "cards.info.series";
+    public static final String INFO_MOB = "cards.info.mob";
+    public static final String INFO_PACK = "cards.info.pack";
 
     private Permissions() {
         throw new UnsupportedOperationException(InternalExceptions.UTIL_CLASS);

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/placeholders/TradingCardsPlaceholderExpansion.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/placeholders/TradingCardsPlaceholderExpansion.java
@@ -116,10 +116,10 @@ public class TradingCardsPlaceholderExpansion extends PlaceholderExpansion {
                 @Override
                 protected String onPlaceholderValue() {
                     return switch (type) {
-                        case "default-color" -> plugin.getRarityManager().getRarity(id).defaultColor();
-                        case "display-name" -> plugin.getRarityManager().getRarity(id).displayName();
-                        case "buy-price" -> String.valueOf(plugin.getRarityManager().getRarity(id).buyPrice());
-                        case "sell-price" -> String.valueOf(plugin.getRarityManager().getRarity(id).sellPrice());
+                        case "default-color" -> plugin.getRarityManager().getRarity(id).getDefaultColor();
+                        case "display-name" -> plugin.getRarityManager().getRarity(id).getDisplayName();
+                        case "buy-price" -> String.valueOf(plugin.getRarityManager().getRarity(id).getBuyPrice());
+                        case "sell-price" -> String.valueOf(plugin.getRarityManager().getRarity(id).getSellPrice());
                         default -> null;
                     };
                 }

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/local/RaritiesConfig.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/local/RaritiesConfig.java
@@ -223,8 +223,8 @@ public class RaritiesConfig extends RarityConfigurate{
             target.node(DISPLAY_NAME).set(rarity.getDisplayName());
             target.node(DEFAULT_COLOR).set(rarity.getDefaultColor());
             target.node(REWARDS).set(rarity.getRewards());
-            target.node(BUY_PRICE).set(rarity.buyPrice());
-            target.node(SELL_PRICE).set(rarity.sellPrice());
+            target.node(BUY_PRICE).set(rarity.getBuyPrice());
+            target.node(SELL_PRICE).set(rarity.getSellPrice());
         }
     }
 

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/local/SimpleCardsConfig.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/local/SimpleCardsConfig.java
@@ -220,7 +220,7 @@ public class SimpleCardsConfig extends YamlConfigurateFile<TradingCards> {
 
         private double getBuyPrice(@NotNull ConfigurationNode node, Rarity rarity) {
             if(node.node(BUY_PRICE).isNull()) {
-                return rarity.buyPrice();
+                return rarity.getBuyPrice();
             } else {
                 return node.node(BUY_PRICE).getDouble(0.0D);
             }
@@ -228,7 +228,7 @@ public class SimpleCardsConfig extends YamlConfigurateFile<TradingCards> {
 
         private double getSellPrice(@NotNull ConfigurationNode node, Rarity rarity){
             if(node.node(SELL_PRICE).isNull()) {
-                return rarity.sellPrice();
+                return rarity.getSellPrice();
             } else {
                 return node.node(SELL_PRICE).getDouble(0.0D);
             }

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/utils/CardUtil.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/utils/CardUtil.java
@@ -32,6 +32,8 @@ public class CardUtil {
     public static final int RANDOM_MAX = 100000;
     public static ItemStack BLANK_CARD;
 
+    private static final DropType EMPTY_TYPE = new DropType("tc-internal-empty", "", "empty");
+
     private CardUtil() {
         throw new UnsupportedOperationException();
     }
@@ -74,7 +76,10 @@ public class CardUtil {
         if (plugin.isMobPassive(e)) {
             return DropTypeManager.PASSIVE;
         }
-        return DropTypeManager.BOSS;
+        if(plugin.isMobBoss(e))
+            return DropTypeManager.BOSS;
+
+        return EMPTY_TYPE;
     }
 
     public static boolean isCard(final ItemStack itemStack) {

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/utils/ChatUtil.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/utils/ChatUtil.java
@@ -43,7 +43,7 @@ public class ChatUtil {
     //We assume that the length of messages & args are the same, we should figure out a way to add a warning about this in intellij
     public static void sendPrefixedMessages(final CommandSender target, final String @NotNull [] messages, Object... args) {
         for (int i = 0; i < messages.length; i++) {
-            sendMessage(target, messages[i].formatted(args[i]));
+            sendPrefixedMessage(target, messages[i].formatted(args[i]));
         }
     }
 

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/utils/ChatUtil.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/utils/ChatUtil.java
@@ -15,51 +15,61 @@ import java.util.List;
 import java.util.stream.Stream;
 
 public class ChatUtil {
-	private static final char ALT_COLOR_CHAR = '&';
-	private static TradingCards plugin;
-	private ChatUtil() {
-		throw new UnsupportedOperationException();
-	}
-	public static void init(final TradingCards plugin){
-		ChatUtil.plugin = plugin;
-	}
+    private static final char ALT_COLOR_CHAR = '&';
+    private static TradingCards plugin;
 
-	public static void sendPrefixedMessage(final CommandSender target, final String message) {
-		sendMessage(target, plugin.getPrefixedMessage(message));
-	}
+    private ChatUtil() {
+        throw new UnsupportedOperationException();
+    }
 
-	public static void sendMessage(final @NotNull CommandSender target, final String message) {
-		com.github.sarhatabaot.kraken.core.chat.ChatUtil.sendMessage(target,message);
-	}
+    public static void init(final TradingCards plugin) {
+        ChatUtil.plugin = plugin;
+    }
 
-	public static void sendPrefixedMessages(final CommandSender target, final String... messages) {
-		List<String> prefixedMessages =  new ArrayList<>();
-		Arrays.stream(messages).forEach(message -> prefixedMessages.add(plugin.getPrefixedMessage(message)));
-		com.github.sarhatabaot.kraken.core.chat.ChatUtil.sendMessage(target, prefixedMessages.toArray(new String[0]));
-	}
+    public static void sendPrefixedMessage(final CommandSender target, final String message) {
+        sendMessage(target, plugin.getPrefixedMessage(message));
+    }
 
-	public static @NotNull String color(Component component) {
-		return LegacyComponentSerializer.builder().character(ALT_COLOR_CHAR).build().serialize(component);
-	}
+    public static void sendMessage(final @NotNull CommandSender target, final String message) {
+        com.github.sarhatabaot.kraken.core.chat.ChatUtil.sendMessage(target, message);
+    }
 
-	@Contract("_ -> new")
-	public static @NotNull String color(String text) {
-		return com.github.sarhatabaot.kraken.core.chat.ChatUtil.color(text);
-	}
+    public static void sendPrefixedMessages(final CommandSender target, final String... messages) {
+        List<String> prefixedMessages = new ArrayList<>();
+        Arrays.stream(messages).forEach(message -> prefixedMessages.add(plugin.getPrefixedMessage(message)));
+        com.github.sarhatabaot.kraken.core.chat.ChatUtil.sendMessage(target, prefixedMessages.toArray(new String[0]));
+    }
 
-	public static @NotNull List<String> wrapString(@NotNull String s) {
-		String parsedString = ChatColor.stripColor(s);
-		String addedString = WordUtils.wrap(parsedString, plugin.getGeneralConfig().infoLineLength(), "\n", true);
-		String[] splitString = addedString.split("\n");
-		List<String> finalArray = new ArrayList<>();
+    //We assume that the length of messages & args are the same, we should figure out a way to add a warning about this in intellij
+    public static void sendPrefixedMessages(final CommandSender target, final String @NotNull [] messages, Object... args) {
+        for (int i = 0; i < messages.length; i++) {
+            sendMessage(target, messages[i].formatted(args[i]));
+        }
+    }
 
-		for (String ss : splitString) {
-			finalArray.add(ChatUtil.color("&f &7- &f" + ss));
-		}
+    public static @NotNull String color(Component component) {
+        return LegacyComponentSerializer.builder().character(ALT_COLOR_CHAR).build().serialize(component);
+    }
 
-		return finalArray;
-	}
-	public static void sendMessage(final @NotNull CommandSender target, final Component text) {
-		target.sendMessage(color(text));
-	}
+    @Contract("_ -> new")
+    public static @NotNull String color(String text) {
+        return com.github.sarhatabaot.kraken.core.chat.ChatUtil.color(text);
+    }
+
+    public static @NotNull List<String> wrapString(@NotNull String s) {
+        String parsedString = ChatColor.stripColor(s);
+        String addedString = WordUtils.wrap(parsedString, plugin.getGeneralConfig().infoLineLength(), "\n", true);
+        String[] splitString = addedString.split("\n");
+        List<String> finalArray = new ArrayList<>();
+
+        for (String ss : splitString) {
+            finalArray.add(ChatUtil.color("&f &7- &f" + ss));
+        }
+
+        return finalArray;
+    }
+
+    public static void sendMessage(final @NotNull CommandSender target, final Component text) {
+        target.sendMessage(color(text));
+    }
 }

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/utils/ChatUtil.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/utils/ChatUtil.java
@@ -10,7 +10,9 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 
 public class ChatUtil {
 	private static final char ALT_COLOR_CHAR = '&';
@@ -28,6 +30,12 @@ public class ChatUtil {
 
 	public static void sendMessage(final @NotNull CommandSender target, final String message) {
 		com.github.sarhatabaot.kraken.core.chat.ChatUtil.sendMessage(target,message);
+	}
+
+	public static void sendPrefixedMessages(final CommandSender target, final String... messages) {
+		List<String> prefixedMessages =  new ArrayList<>();
+		Arrays.stream(messages).forEach(message -> prefixedMessages.add(plugin.getPrefixedMessage(message)));
+		com.github.sarhatabaot.kraken.core.chat.ChatUtil.sendMessage(target, prefixedMessages.toArray(new String[0]));
 	}
 
 	public static @NotNull String color(Component component) {


### PR DESCRIPTION
This PR adds an info command. 
You can now view the changes made to objects without opening the storage file or database.

`/cards info card <rarityId> <seriesId> <cardId>` - `cards.info.card`
`/cards info pack <packId>` - `cards.info.pack`
`/cards info series <seriesId>` - `cards.info.series`
`/cards info type <typeId>` -  `cards.info.type`
`/cards info type <rarityId>` - `cards.info.rarity`

