### PR TITLE
Fixes #161

### DIFF
--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/listeners/DropListener.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/listeners/DropListener.java
@@ -76,7 +76,7 @@ public class DropListener extends SimpleListener {
         if (!this.worldBlacklist.isAllowed(world)) return;
 
         NBTEntity nbtEntity = new NBTEntity(killedEntity);
-        if(nbtEntity.hasKey(NbtUtils.TC_COMPOUND) && nbtEntity.getCompound(NbtUtils.TC_COMPOUND).hasKey(NbtUtils.TC_SPAWNER_MOB)) {
+        if(nbtEntity.getPersistentDataContainer().hasKey(NbtUtils.TC_COMPOUND) && nbtEntity.getPersistentDataContainer().getCompound(NbtUtils.TC_COMPOUND).hasKey(NbtUtils.TC_SPAWNER_MOB)) {
             debug("Entity %s is marked as a spawner entity, not dropping card.".formatted(killedEntity.getType()));
             return;
         }

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/listeners/SpawnerListener.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/listeners/SpawnerListener.java
@@ -1,5 +1,6 @@
 package net.tinetwork.tradingcards.tradingcardsplugin.listeners;
 
+import de.tr7zw.nbtapi.NBTCompound;
 import de.tr7zw.nbtapi.NBTEntity;
 import net.tinetwork.tradingcards.api.utils.NbtUtils;
 import net.tinetwork.tradingcards.tradingcardsplugin.TradingCards;
@@ -10,7 +11,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * @author sarhatabaot
  */
-public class SpawnerListener extends SimpleListener{
+public class SpawnerListener extends SimpleListener {
     public SpawnerListener(final @NotNull TradingCards plugin) {
         super(plugin);
     }
@@ -18,8 +19,10 @@ public class SpawnerListener extends SimpleListener{
     @EventHandler
     public void onMobSpawn(@NotNull SpawnerSpawnEvent event) {
         NBTEntity nbtEntity = new NBTEntity(event.getEntity());
-        nbtEntity.getOrCreateCompound(NbtUtils.TC_COMPOUND).setBoolean(NbtUtils.TC_SPAWNER_MOB, true);
 
+        NBTCompound tcCompound = nbtEntity.getPersistentDataContainer().getOrCreateCompound(NbtUtils.TC_COMPOUND);
+        tcCompound.setBoolean(NbtUtils.TC_SPAWNER_MOB, true);
         debug("Set key %s to true on entity %s @ %s ".formatted(NbtUtils.TC_SPAWNER_MOB, event.getEntityType(), event.getLocation().toString()));
     }
+
 }


### PR DESCRIPTION
We cannot add custom compounds directly to an entity. We must get the persistendatacontainer first.