### PR TITLE
Sql first time

### DIFF
--- a/tradingcards-api/src/main/java/net/tinetwork/tradingcards/api/config/settings/StorageConfigurate.java
+++ b/tradingcards-api/src/main/java/net/tinetwork/tradingcards/api/config/settings/StorageConfigurate.java
@@ -27,4 +27,6 @@ public abstract class StorageConfigurate extends YamlConfigurateFile<TradingCard
     public abstract String getDefaultSeriesId();
 
     public abstract String getDefaultCardsFile();
+
+    public abstract boolean isFirstTimeValues();
 }

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/config/settings/StorageConfig.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/config/settings/StorageConfig.java
@@ -100,6 +100,10 @@ public class StorageConfig extends StorageConfigurate {
         return defaultSeriesId;
     }
 
+    public boolean isFirstTimeValues() {
+        return firstTimeValues;
+    }
+
     @Override
     public String getDefaultCardsFile() {
         return defaultCardsFile;

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/config/settings/StorageConfig.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/config/settings/StorageConfig.java
@@ -29,6 +29,8 @@ public class StorageConfig extends StorageConfigurate {
 
     private String defaultCardsFile;
 
+    private boolean firstTimeValues;
+
 
     public StorageConfig(final TradingCards plugin) throws ConfigurateException {
         super(plugin, "settings" + File.separator, "storage.yml", "settings");
@@ -51,6 +53,9 @@ public class StorageConfig extends StorageConfigurate {
 
         final ConfigurationNode dbMigration = rootNode.node("database-migration");
         this.defaultSeriesId = dbMigration.node("default-series-id").getString(Storage.DatabaseMigration.DEFAULT_SERIES_ID);
+
+        final ConfigurationNode sql = rootNode.node("sql");
+        this.firstTimeValues = sql.node("first-time-values").getBoolean(Storage.Sql.FIRST_TIME_VALUES);
     }
 
     @Override

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/config/transformations/StorageTransformations.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/config/transformations/StorageTransformations.java
@@ -1,6 +1,7 @@
 package net.tinetwork.tradingcards.tradingcardsplugin.config.transformations;
 
 import com.github.sarhatabaot.kraken.core.config.Transformation;
+import net.tinetwork.tradingcards.tradingcardsplugin.messages.settings.Storage;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.configurate.transformation.ConfigurationTransformation;
@@ -13,7 +14,7 @@ import static org.spongepowered.configurate.NodePath.path;
 public class StorageTransformations extends Transformation {
     @Override
     public int getLatestVersion() {
-        return 1;
+        return 2;
     }
 
     @Override
@@ -22,6 +23,7 @@ public class StorageTransformations extends Transformation {
                 .versionKey("config-version")
                 .addVersion(0, initialTransformation())
                 .addVersion(1, addDefaultMigrationId())
+                .addVersion(2,addSqlFirstTime())
                 .build();
     }
 
@@ -30,6 +32,16 @@ public class StorageTransformations extends Transformation {
         return ConfigurationTransformation.builder()
                 .addAction(path("database-migration", ConfigurationTransformation.WILDCARD_OBJECT), (path, value) -> {
                     value.node("default-series-id").set("default");
+                    return null;
+                })
+                .build();
+    }
+
+    @Contract(" -> new")
+    private @NotNull ConfigurationTransformation addSqlFirstTime() {
+        return ConfigurationTransformation.builder()
+                .addAction(path("sql", ConfigurationTransformation.WILDCARD_OBJECT), (path, value) -> {
+                    value.node("first-time-values").set(Storage.Sql.FIRST_TIME_VALUES);
                     return null;
                 })
                 .build();

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/managers/cards/AllCardManager.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/managers/cards/AllCardManager.java
@@ -17,19 +17,17 @@ import net.tinetwork.tradingcards.tradingcardsplugin.managers.TradingRarityManag
 import net.tinetwork.tradingcards.tradingcardsplugin.messages.internal.InternalDebug;
 import net.tinetwork.tradingcards.tradingcardsplugin.messages.internal.InternalLog;
 import net.tinetwork.tradingcards.tradingcardsplugin.utils.CardUtil;
-import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
-public class AllCardManager extends TradingCardManager implements CardManager<TradingCard>{
+public class AllCardManager extends TradingCardManager implements CardManager<TradingCard> {
     public static final EmptyCard NULL_CARD = new EmptyCard();
     private List<CompositeCardKey> keys;
 
@@ -81,6 +79,9 @@ public class AllCardManager extends TradingCardManager implements CardManager<Tr
     @Override
     public List<String> getCardsIdsInRarityAndSeries(final String rarityId, final String seriesId) {
         try {
+            if (this.rarityAndSeriesCardCache.size() == 0) {
+                return Collections.emptyList();
+            }
             return this.rarityAndSeriesCardCache.get(CompositeRaritySeriesKey.of(rarityId, seriesId)).stream().map(TradingCard::getCardId).toList();
         } catch (ExecutionException e) {
             LoggerUtil.logSevereException(e);
@@ -104,7 +105,7 @@ public class AllCardManager extends TradingCardManager implements CardManager<Tr
 
     @Override
     public List<String> getRarityCardListIds(final String rarityId) {
-        if(this.rarityCardCache.getIfPresent(rarityId) == null)
+        if (this.rarityCardCache.getIfPresent(rarityId) == null)
             return Collections.emptyList();
 
         return this.rarityCardCache.getUnchecked(rarityId).stream().map(TradingCard::getCardId).toList();
@@ -114,12 +115,12 @@ public class AllCardManager extends TradingCardManager implements CardManager<Tr
     public List<String> getActiveRarityCardIds(final String rarity) {
         try {
             List<String> allCardIds = new ArrayList<>();
-            for(List<TradingCard> cardList: rarityCardCache.getAll(getActiveRarityIds()).values()) {
+            for (List<TradingCard> cardList : rarityCardCache.getAll(getActiveRarityIds()).values()) {
                 allCardIds = Stream.concat(allCardIds.stream(), cardList.stream().map(TradingCard::getCardId)).toList();
             }
             return allCardIds;
         } catch (ExecutionException e) {
-            plugin.debug(getClass(),e.getMessage());
+            plugin.debug(getClass(), e.getMessage());
             return Collections.emptyList();
         }
     }
@@ -137,7 +138,7 @@ public class AllCardManager extends TradingCardManager implements CardManager<Tr
     @Override
     public TradingCard getCard(final String cardId, final String rarityId, final String seriesId) {
         try {
-            return cache.get(new CompositeCardKey(rarityId,seriesId,cardId));
+            return cache.get(new CompositeCardKey(rarityId, seriesId, cardId));
         } catch (ExecutionException | NullPointerException e) {
             LoggerUtil.logSevereException(e);
             return NULL_CARD;
@@ -156,7 +157,7 @@ public class AllCardManager extends TradingCardManager implements CardManager<Tr
 
     @Override
     public TradingCard getRandomCardByRarity(final String rarityId) {
-        plugin.debug(AllCardManager.class,InternalDebug.CardsManager.RANDOM_CARD.formatted(rarityId));
+        plugin.debug(AllCardManager.class, InternalDebug.CardsManager.RANDOM_CARD.formatted(rarityId));
         int cardIndex = plugin.getRandom().nextInt(getRarityCardList(rarityId).size());
         return getRarityCardList(rarityId).get(cardIndex);
     }
@@ -169,8 +170,8 @@ public class AllCardManager extends TradingCardManager implements CardManager<Tr
     }
 
     public TradingCard getRandomCardByRarityAndSeries(final String rarityId, final String seriesId) {
-        List<TradingCard> raritySeries = plugin.getStorage().getCardsInRarityAndSeries(rarityId,seriesId);
-        if(raritySeries== null || raritySeries.isEmpty())
+        List<TradingCard> raritySeries = plugin.getStorage().getCardsInRarityAndSeries(rarityId, seriesId);
+        if (raritySeries == null || raritySeries.isEmpty())
             return NULL_CARD;
 
         int cardIndex = plugin.getRandom().nextInt(raritySeries.size());
@@ -197,13 +198,13 @@ public class AllCardManager extends TradingCardManager implements CardManager<Tr
     public String getRandomRarityId(DropType dropType, boolean alwaysDrop) {
         int randomDropChance = plugin.getRandom().nextInt(CardUtil.RANDOM_MAX) + 1;
         int mobDropChance = getGeneralMobChance(dropType);
-        plugin.debug(AllCardManager.class,InternalDebug.CardsManager.DROP_CHANCE.formatted(randomDropChance,alwaysDrop,dropType,mobDropChance));
+        plugin.debug(AllCardManager.class, InternalDebug.CardsManager.DROP_CHANCE.formatted(randomDropChance, alwaysDrop, dropType, mobDropChance));
         if (!alwaysDrop && randomDropChance > mobDropChance) {
             return TradingRarityManager.EMPTY_RARITY.getId();
         }
 
         int randomRarityChance = plugin.getRandom().nextInt(CardUtil.RANDOM_MAX) + 1;
-        plugin.debug(AllCardManager.class,InternalDebug.CardsManager.RARITY_CHANCE.formatted(randomRarityChance));
+        plugin.debug(AllCardManager.class, InternalDebug.CardsManager.RARITY_CHANCE.formatted(randomRarityChance));
 
         for (String rarity : plugin.getRarityManager().getRarityIds()) {
             Chance chance = plugin.getChancesConfig().getChance(rarity);
@@ -220,16 +221,16 @@ public class AllCardManager extends TradingCardManager implements CardManager<Tr
 
     @Override
     public boolean containsCard(final String cardId, final String rarityId, final String seriesId) {
-        CompositeCardKey cardKey = new CompositeCardKey(rarityId,seriesId,cardId);
+        CompositeCardKey cardKey = new CompositeCardKey(rarityId, seriesId, cardId);
         return cache.getIfPresent(cardKey) != null;
     }
 
     @Override
     public List<CompositeCardKey> getKeys() {
-        if(this.keys == null) {
+        if (this.keys == null) {
             this.keys = new ArrayList<>();
-            for(TradingCard card: plugin.getStorage().getCards()) {
-                keys.add(new CompositeCardKey(card.getRarity().getId(),card.getSeries().getId(),card.getCardId()));
+            for (TradingCard card : plugin.getStorage().getCards()) {
+                keys.add(new CompositeCardKey(card.getRarity().getId(), card.getSeries().getId(), card.getCardId()));
             }
         }
 

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/messages/settings/Storage.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/messages/settings/Storage.java
@@ -13,6 +13,14 @@ public final class Storage {
         }
     }
 
+    public static class Sql {
+        public static final Boolean FIRST_TIME_VALUES = false;
+
+        private Sql() {
+            throw new UnsupportedOperationException(InternalExceptions.UTIL_CLASS);
+        }
+    }
+
     public static class Database {
         public static final String ADDRESS = "localhost";
         public static final Integer PORT = 3306;

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/remote/SqlStorage.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/remote/SqlStorage.java
@@ -97,11 +97,33 @@ public class SqlStorage implements Storage<TradingCard> {
         try {
             applySchema();
 
+            createFirstTimeValues();
             createCardsInRarityViews();
             createCardsInSeriesViews();
             createCardsInRarityAndSeriesViews();
         } catch (SQLException | IOException e) {
             plugin.getLogger().severe(e.getMessage());
+        }
+    }
+
+    private void createFirstTimeValues() {
+        if(!plugin.getStorageConfig().isFirstTimeValues()) {
+            return;
+        }
+
+        List<String> rarityList = List.of("common","uncommon","rare","very-rare","legendary");
+        for(String rarityId: rarityList) {
+            createRarity(rarityId);
+        }
+        Map<String, Mode> defaultSeries = Map.of("default", Mode.ACTIVE, "halloween", Mode.DISABLED);
+        for(Map.Entry<String,Mode> entry:defaultSeries.entrySet()) {
+            createSeries(entry.getKey());
+            editSeriesMode(entry.getKey(),entry.getValue());
+        }
+
+        List<String> cardIds = List.of("zombie","skeleton", "creeper");
+        for(String cardId: cardIds) {
+            createCard(cardId, "common","default");
         }
     }
 

--- a/tradingcards-plugin/src/main/resources/settings/storage.yml
+++ b/tradingcards-plugin/src/main/resources/settings/storage.yml
@@ -5,6 +5,10 @@ yaml:
   # Default file to create & edit cards in.
   default-file: "cards.yml"
 
+sql:
+  # Generate first time values for sql database.
+  first-time-values: false
+
 database:
   # Address and port for the database.
   address: localhost


### PR DESCRIPTION
Adds a new config option to storage.yml

```yaml
sql:
  first-time-values: false
```

Set it to true if you want to generate some generic values when you load up an sql instance.