### PR TITLE
Standalone api

### DIFF
--- a/tradingcards-api/pom.xml
+++ b/tradingcards-api/pom.xml
@@ -3,14 +3,23 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>net.tinetwork.tradingcards</groupId>
-        <artifactId>tradingcards-parent</artifactId>
-        <version>5.7.10</version>
-    </parent>
+<!--    <parent>-->
+<!--        <groupId>net.tinetwork.tradingcards</groupId>-->
+<!--        <artifactId>tradingcards-parent</artifactId>-->
+<!--        <version>5.7.10</version>-->
+<!--    </parent>-->
+
+    <groupId>net.tinetwork.tradingcards</groupId>
+    <artifactId>tradingcards-api</artifactId>
+    <version>5.7.10</version>
 
     <packaging>jar</packaging>
-    <artifactId>tradingcards-api</artifactId>
+
+    <properties>
+        <spigot.version>1.18.2-R0.1-SNAPSHOT</spigot.version>
+        <item.nbt.version>2.10.0</item.nbt.version>
+        <maven.compiler.version>3.10.1</maven.compiler.version>
+    </properties>
 
     <name>TradingCards API</name>
     <build>
@@ -55,17 +64,16 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>${spigot.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>de.tr7zw</groupId>
             <artifactId>item-nbt-api-plugin</artifactId>
             <version>${item.nbt.version}</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>co.aikar</groupId>
-            <artifactId>acf-paper</artifactId>
-            <version>${acf.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
     </dependencies>
 </project>

--- a/tradingcards-api/pom.xml
+++ b/tradingcards-api/pom.xml
@@ -3,12 +3,6 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-<!--    <parent>-->
-<!--        <groupId>net.tinetwork.tradingcards</groupId>-->
-<!--        <artifactId>tradingcards-parent</artifactId>-->
-<!--        <version>5.7.10</version>-->
-<!--    </parent>-->
-
     <groupId>net.tinetwork.tradingcards</groupId>
     <artifactId>tradingcards-api</artifactId>
     <version>5.7.10</version>
@@ -16,9 +10,17 @@
     <packaging>jar</packaging>
 
     <properties>
+        <java.version>17</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
         <spigot.version>1.18.2-R0.1-SNAPSHOT</spigot.version>
         <item.nbt.version>2.10.0</item.nbt.version>
         <maven.compiler.version>3.10.1</maven.compiler.version>
+        <kraken.core.version>1.6.2</kraken.core.version>
+        <vault.api.version>1.7.1</vault.api.version>
+        <jetbrains.annotations.version>23.0.0</jetbrains.annotations.version>
+        <configurate.version>4.1.2</configurate.version>
+        <treasury.version>1.2.1</treasury.version>
     </properties>
 
     <name>TradingCards API</name>
@@ -52,6 +54,10 @@
 
     <repositories>
         <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+        <repository>
             <id>codemc-repo</id>
             <url>https://repo.codemc.org/repository/maven-public/</url>
             <layout>default</layout>
@@ -73,6 +79,36 @@
             <groupId>de.tr7zw</groupId>
             <artifactId>item-nbt-api-plugin</artifactId>
             <version>${item.nbt.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.sarhatabaot</groupId>
+            <artifactId>krakencore</artifactId>
+            <version>${kraken.core.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.MilkBowl</groupId>
+            <artifactId>VaultAPI</artifactId>
+            <version>${vault.api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>${jetbrains.annotations.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.spongepowered</groupId>
+            <artifactId>configurate-yaml</artifactId>
+            <version>${configurate.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>me.lokka30</groupId>
+            <artifactId>treasury-api</artifactId>
+            <version>${treasury.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/tradingcards-plugin/pom.xml
+++ b/tradingcards-plugin/pom.xml
@@ -31,6 +31,8 @@
         <adventure.bukkit.version>4.1.2</adventure.bukkit.version>
         <placeholderapi.version>2.11.2</placeholderapi.version>
 
+        <tradingcards.api.version>5.7.10</tradingcards.api.version>
+
         <!-- Tests -->
         <mockito.version>4.9.0</mockito.version>
         <mockbukkit.version>2.85.2</mockbukkit.version>
@@ -43,7 +45,7 @@
         <!-- Others -->
         <zip4j.version>2.11.2</zip4j.version>
 
-        <sql.schema.version>V0_mysql.sql</sql.schema.version>
+        <sql.schema.version>V0_mysql.sql</sql.schema.version> <!-- TODO -->
     </properties>
 
     <pluginRepositories>
@@ -384,7 +386,7 @@
         <dependency>
             <groupId>net.tinetwork.tradingcards</groupId>
             <artifactId>tradingcards-api</artifactId>
-            <version>${project.version}</version>
+            <version>${tradingcards.api.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This separates the api from the main project. 
It doesn't make sense that with every version bump the api gets bumped even if there are not changes to it.

The current api version is 5.7.10, matching with the plugin version, from this point onwards the api version will change only if changes have been made to it.