### PR TITLE
fix: store CustomModelData in minecraft:custom_model_data component

### DIFF
--- a/tradingcards-api/src/main/java/net/tinetwork/tradingcards/api/card/Card.java
+++ b/tradingcards-api/src/main/java/net/tinetwork/tradingcards/api/card/Card.java
@@ -198,10 +198,6 @@ public abstract class Card<T> {
         nbtCompound.setBoolean(NbtUtils.TC_CARD_SHINY, shiny);
         nbtCompound.setString(NbtUtils.TC_CARD_SERIES, series.getId());
 
-        if (getCustomModelNbt() != 0) {
-            nbtItem.setInteger(NbtUtils.NBT_CARD_CUSTOM_MODEL, this.cardMeta.getCustomModelNbt());
-        }
-
         return nbtItem;
     }
 

--- a/tradingcards-api/src/main/java/net/tinetwork/tradingcards/api/utils/NbtUtils.java
+++ b/tradingcards-api/src/main/java/net/tinetwork/tradingcards/api/utils/NbtUtils.java
@@ -14,7 +14,6 @@ import java.util.Objects;
  properly anymore.!!
  */
 public class NbtUtils {
-    public static final String NBT_CARD_CUSTOM_MODEL = "CustomModelData";
     public static final String TC_COMPOUND = "trading-cards";
 
     // Deck Stuff

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/card/TradingCard.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/card/TradingCard.java
@@ -40,6 +40,9 @@ public class TradingCard extends Card<TradingCard> {
             cardMeta.addEnchant(Enchantment.INFINITY, 1, false);
         }
         cardMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+        if (getCustomModelNbt() != 0) {
+            cardMeta.setCustomModelData(getCustomModelNbt());
+        }
         cardItemStack.setItemMeta(cardMeta);
 
         return cardItemStack;

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/managers/impl/TradingDeckManager.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/managers/impl/TradingDeckManager.java
@@ -166,15 +166,19 @@ public class TradingDeckManager implements DeckManager {
     @NotNull
     @Override
     public ItemStack getNbtItem(@NotNull final Player player, final int deckNumber) {
-        NBTItem nbtItem = new NBTItem(createDeckItem(player, deckNumber));
-        NBTCompound nbtCompound = nbtItem.getOrCreateCompound(NbtUtils.TC_COMPOUND);
-        nbtCompound.setInteger(NbtUtils.TC_DECK_NUMBER, deckNumber);
+        ItemStack deckItemStack = createDeckItem(player, deckNumber);
         int customModelData = plugin.getGeneralConfig().deckCustomModelData();
 
         plugin.debug(TradingDeckManager.class,"CustomModelData = "+customModelData);
-        if(customModelData != 0) {
-            nbtItem.setInteger(NbtUtils.NBT_CARD_CUSTOM_MODEL, customModelData);
+        if (customModelData != 0) {
+            ItemMeta meta = deckItemStack.getItemMeta();
+            meta.setCustomModelData(customModelData);
+            deckItemStack.setItemMeta(meta);
         }
+
+        NBTItem nbtItem = new NBTItem(deckItemStack);
+        NBTCompound nbtCompound = nbtItem.getOrCreateCompound(NbtUtils.TC_COMPOUND);
+        nbtCompound.setInteger(NbtUtils.TC_DECK_NUMBER, deckNumber);
 
         return nbtItem.getItem();
     }


### PR DESCRIPTION
Previously, CustomModelData was written via nbtItem.setInteger() which in Minecraft 1.20.5+ routes the value into the minecraft:custom_data blob rather than the standalone minecraft:custom_model_data component. Resource packs cannot query the value from inside custom_data, so card textures were not applying.

Changes:
- TradingCard.buildItem(): call cardMeta.setCustomModelData() via the Bukkit ItemMeta API so the value is stored in the proper minecraft:custom_model_data component
- Card.buildNBTItem(): remove the nbtItem.setInteger("CustomModelData", ...) call that was incorrectly routing the value into custom_data
- TradingDeckManager.getNbtItem(): apply deck custom model data through ItemMeta before wrapping the item in NBTItem, same fix as above
- NbtUtils: remove the now-unused NBT_CARD_CUSTOM_MODEL constant

Resource packs should now select card models using minecraft:custom_model_data (range_dispatch with float thresholds) instead of minecraft:custom_data.