### PR TITLE
Feature/498 dialogs

### DIFF
--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/EditCommand.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/EditCommand.java
@@ -30,6 +30,7 @@ import net.tinetwork.tradingcards.tradingcardsplugin.commands.edit.PackEditServi
 import net.tinetwork.tradingcards.tradingcardsplugin.commands.edit.RarityEditService;
 import net.tinetwork.tradingcards.tradingcardsplugin.commands.edit.SeriesEditService;
 import net.tinetwork.tradingcards.tradingcardsplugin.commands.edit.TypeEditService;
+import net.tinetwork.tradingcards.tradingcardsplugin.commands.edit.UpgradeEditService;
 import net.tinetwork.tradingcards.tradingcardsplugin.storage.Storage;
 import net.tinetwork.tradingcards.tradingcardsplugin.utils.ChatUtil;
 import net.tinetwork.tradingcards.tradingcardsplugin.utils.Util;
@@ -51,6 +52,7 @@ public class EditCommand extends BaseCommand {
     private final RarityEditService rarityEditService;
     private final SeriesEditService seriesEditService;
     private final TypeEditService typeEditService;
+    private final UpgradeEditService upgradeEditService;
 
     public EditCommand(final @NotNull TradingCards plugin) {
         this.plugin = plugin;
@@ -59,6 +61,7 @@ public class EditCommand extends BaseCommand {
         this.rarityEditService = new RarityEditService(plugin);
         this.seriesEditService = new SeriesEditService(plugin);
         this.typeEditService = new TypeEditService(plugin);
+        this.upgradeEditService = new UpgradeEditService(plugin);
     }
 
     @Subcommand("edit")
@@ -430,6 +433,21 @@ public class EditCommand extends BaseCommand {
             }
             plugin.getDropTypeManager().getCache().refresh(typeId);
             sendSetTypes(sender, typeId, editType, value);
+        }
+
+        @Subcommand("upgrade")
+        @CommandPermission(Permissions.Admin.Edit.EDIT_UPGRADE)
+        @Description("Open the upgrade editor dialog.")
+        public void onEditUpgrade(final CommandSender sender, final String upgradeId) {
+            if(!plugin.getUpgradeManager().containsUpgrade(upgradeId)) {
+                ChatUtil.sendPrefixedMessage(sender, InternalMessages.NO_UPGRADE.formatted(upgradeId));
+                return;
+            }
+            if (!(sender instanceof org.bukkit.entity.Player player)) {
+                ChatUtil.sendPrefixedMessage(sender, "&4This editor can only be opened by a player.");
+                return;
+            }
+            upgradeEditService.openEditor(player, upgradeId);
         }
 
         @Subcommand("upgrade")

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/EditCommand.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/EditCommand.java
@@ -20,6 +20,7 @@ import net.tinetwork.tradingcards.tradingcardsplugin.messages.internal.InternalM
 import net.tinetwork.tradingcards.tradingcardsplugin.messages.internal.Permissions;
 import net.tinetwork.tradingcards.tradingcardsplugin.TradingCards;
 import net.tinetwork.tradingcards.tradingcardsplugin.card.TradingCard;
+import net.tinetwork.tradingcards.tradingcardsplugin.commands.edit.CardEditService;
 import net.tinetwork.tradingcards.tradingcardsplugin.commands.edit.Edit;
 import net.tinetwork.tradingcards.tradingcardsplugin.commands.edit.EditCard;
 import net.tinetwork.tradingcards.tradingcardsplugin.commands.edit.EditPack;
@@ -48,6 +49,7 @@ import java.util.List;
 public class EditCommand extends BaseCommand {
     private final TradingCards plugin;
     private final Storage<TradingCard> storage;
+    private final CardEditService cardEditService;
     private final PackEditService packEditService;
     private final RarityEditService rarityEditService;
     private final SeriesEditService seriesEditService;
@@ -57,6 +59,7 @@ public class EditCommand extends BaseCommand {
     public EditCommand(final @NotNull TradingCards plugin) {
         this.plugin = plugin;
         this.storage = plugin.getStorage();
+        this.cardEditService = new CardEditService(plugin);
         this.packEditService = new PackEditService(plugin);
         this.rarityEditService = new RarityEditService(plugin);
         this.seriesEditService = new SeriesEditService(plugin);
@@ -68,6 +71,33 @@ public class EditCommand extends BaseCommand {
     @CommandPermission(Permissions.Admin.Edit.EDIT)
     @Description("Edit any value.")
     public class EditSubCommand extends BaseCommand {
+
+        @Subcommand("card")
+        @CommandPermission(Permissions.Admin.Edit.EDIT_CARD)
+        @CommandCompletion("@rarities @series @command-cards")
+        @Description("Open the card editor dialog.")
+        public void onEditCard(final CommandSender sender, final Rarity rarity, final Series series, final String cardId) {
+            final String seriesId = series.getId();
+            final String rarityId = rarity.getId();
+            if (!plugin.getRarityManager().containsRarity(rarityId)) {
+                ChatUtil.sendPrefixedMessage(sender, InternalMessages.NO_RARITY.formatted(rarityId));
+                return;
+            }
+            if (!plugin.getSeriesManager().containsSeries(seriesId)) {
+                ChatUtil.sendPrefixedMessage(sender, InternalMessages.NO_SERIES.formatted(seriesId));
+                return;
+            }
+            if (!plugin.getCardManager().containsCard(cardId, rarityId, seriesId)) {
+                ChatUtil.sendPrefixedMessage(sender, InternalMessages.NO_CARD.formatted(StringUtils.join(List.of(cardId, rarityId, seriesId), "&r,&4 ")));
+                return;
+            }
+            if (!(sender instanceof org.bukkit.entity.Player player)) {
+                ChatUtil.sendPrefixedMessage(sender, "&4This editor can only be opened by a player.");
+                return;
+            }
+
+            cardEditService.openEditor(player, rarityId, seriesId, cardId);
+        }
 
         @Subcommand("card")
         @CommandPermission(Permissions.Admin.Edit.EDIT_CARD)
@@ -88,6 +118,7 @@ public class EditCommand extends BaseCommand {
                 return;
             }
 
+            String updatedSeriesId = seriesId;
             switch (editCard) {
                 case DISPLAY_NAME -> storage.editCardDisplayName(rarityId, cardId, seriesId, value);
                 case SELL_PRICE -> {
@@ -121,7 +152,15 @@ public class EditCommand extends BaseCommand {
                         ChatUtil.sendPrefixedMessage(sender, InternalMessages.NO_SERIES.formatted(value));
                         return;
                     }
-                    storage.editCardSeries(rarityId, cardId, seriesId, series);
+
+                    if (!seriesId.equals(value) && plugin.getCardManager().containsCard(cardId, rarityId, value)) {
+                        ChatUtil.sendPrefixedMessage(sender, "&4Card already exists for &c%s".formatted("%s, %s, %s".formatted(cardId, rarityId, value)));
+                        return;
+                    }
+
+                    final Series targetSeries = plugin.getSeriesManager().getSeries(value);
+                    storage.editCardSeries(rarityId, cardId, seriesId, targetSeries);
+                    updatedSeriesId = value;
                 }
                 case BUY_PRICE -> {
                     double buyPrice = getDoubleFromString(value);
@@ -139,8 +178,8 @@ public class EditCommand extends BaseCommand {
 
             }
 
-            plugin.getCardManager().getCache().refresh(new CompositeCardKey(rarityId,seriesId,cardId));
-            String setCardMessage = "%s %s %s".formatted(cardId,rarityId,seriesId);
+            cardEditService.refreshCardCaches(rarityId, cardId, seriesId, updatedSeriesId);
+            String setCardMessage = "%s %s %s".formatted(cardId,rarityId,updatedSeriesId);
             sendSetTypes(sender, setCardMessage, editCard, value);
         }
 

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/EditCommand.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/EditCommand.java
@@ -26,6 +26,10 @@ import net.tinetwork.tradingcards.tradingcardsplugin.commands.edit.EditPack;
 import net.tinetwork.tradingcards.tradingcardsplugin.commands.edit.EditRarity;
 import net.tinetwork.tradingcards.tradingcardsplugin.commands.edit.EditSeries;
 import net.tinetwork.tradingcards.tradingcardsplugin.commands.edit.EditType;
+import net.tinetwork.tradingcards.tradingcardsplugin.commands.edit.PackEditService;
+import net.tinetwork.tradingcards.tradingcardsplugin.commands.edit.RarityEditService;
+import net.tinetwork.tradingcards.tradingcardsplugin.commands.edit.SeriesEditService;
+import net.tinetwork.tradingcards.tradingcardsplugin.commands.edit.TypeEditService;
 import net.tinetwork.tradingcards.tradingcardsplugin.storage.Storage;
 import net.tinetwork.tradingcards.tradingcardsplugin.utils.ChatUtil;
 import net.tinetwork.tradingcards.tradingcardsplugin.utils.Util;
@@ -43,10 +47,18 @@ import java.util.List;
 public class EditCommand extends BaseCommand {
     private final TradingCards plugin;
     private final Storage<TradingCard> storage;
+    private final PackEditService packEditService;
+    private final RarityEditService rarityEditService;
+    private final SeriesEditService seriesEditService;
+    private final TypeEditService typeEditService;
 
     public EditCommand(final @NotNull TradingCards plugin) {
         this.plugin = plugin;
         this.storage = plugin.getStorage();
+        this.packEditService = new PackEditService(plugin);
+        this.rarityEditService = new RarityEditService(plugin);
+        this.seriesEditService = new SeriesEditService(plugin);
+        this.typeEditService = new TypeEditService(plugin);
     }
 
     @Subcommand("edit")
@@ -131,6 +143,21 @@ public class EditCommand extends BaseCommand {
 
         @Subcommand("rarity")
         @CommandPermission(Permissions.Admin.Edit.EDIT_RARITY)
+        @Description("Open the rarity editor dialog.")
+        public void onEditRarity(final CommandSender sender, final String rarityId) {
+            if (!plugin.getRarityManager().containsRarity(rarityId)) {
+                ChatUtil.sendPrefixedMessage(sender, InternalMessages.NO_RARITY.formatted(rarityId));
+                return;
+            }
+            if (!(sender instanceof org.bukkit.entity.Player player)) {
+                ChatUtil.sendPrefixedMessage(sender, "&4This editor can only be opened by a player.");
+                return;
+            }
+            rarityEditService.openEditor(player, rarityId);
+        }
+
+        @Subcommand("rarity")
+        @CommandPermission(Permissions.Admin.Edit.EDIT_RARITY)
         @CommandCompletion("@rarities @edit-rarity @edit-rarity-value")
         public void onEditRarity(final CommandSender sender, final String rarityId, final EditRarity editRarity, final String value) {
             if (!plugin.getRarityManager().containsRarity(rarityId)) {
@@ -176,6 +203,21 @@ public class EditCommand extends BaseCommand {
             sendSetTypes(sender, rarityId, editRarity, value);
         }
 
+
+        @Subcommand("series")
+        @CommandPermission(Permissions.Admin.Edit.EDIT_SERIES)
+        @Description("Open the series editor dialog.")
+        public void onEditSeries(final CommandSender sender, final String seriesId) {
+            if (!plugin.getSeriesManager().containsSeries(seriesId)) {
+                ChatUtil.sendPrefixedMessage(sender, InternalMessages.NO_SERIES.formatted(seriesId));
+                return;
+            }
+            if (!(sender instanceof org.bukkit.entity.Player player)) {
+                ChatUtil.sendPrefixedMessage(sender, "&4This editor can only be opened by a player.");
+                return;
+            }
+            seriesEditService.openEditor(player, seriesId);
+        }
 
         @Subcommand("series")
         @CommandPermission(Permissions.Admin.Edit.EDIT_SERIES)
@@ -249,6 +291,25 @@ public class EditCommand extends BaseCommand {
                 return -1;
             }
             return lineNumber;
+        }
+
+        //cards edit pack <packId> [displayName|price|permission|contents] (typeCompletion or nothing)
+        @Subcommand("pack")
+        @CommandCompletion("@packs")
+        @CommandPermission(Permissions.Admin.Edit.EDIT_PACK)
+        @Description("Open the pack editor dialog.")
+        public void onEditPack(final CommandSender sender, final String packId) {
+            if (!plugin.getStorage().containsPack(packId)) {
+                ChatUtil.sendPrefixedMessage(sender, InternalMessages.NO_PACK.formatted(packId));
+                return;
+            }
+
+            if (!(sender instanceof org.bukkit.entity.Player player)) {
+                ChatUtil.sendPrefixedMessage(sender, "&4This editor can only be opened by a player.");
+                return;
+            }
+
+            packEditService.openScalarEditor(player, packId);
         }
 
         //cards edit pack <packId> [displayName|price|permission|contents] (typeCompletion or nothing)
@@ -330,6 +391,21 @@ public class EditCommand extends BaseCommand {
         }
 
         //cards edit type <typeId> [type|displayName] (typeCompletion or nothing)
+        @Subcommand("type")
+        @CommandPermission(Permissions.Admin.Edit.EDIT_CUSTOM_TYPE)
+        @Description("Open the custom type editor dialog.")
+        public void onEditType(final CommandSender sender, final String typeId) {
+            if (!plugin.getDropTypeManager().containsType(typeId)) {
+                ChatUtil.sendPrefixedMessage(sender, InternalMessages.NO_TYPE.formatted(typeId));
+                return;
+            }
+            if (!(sender instanceof org.bukkit.entity.Player player)) {
+                ChatUtil.sendPrefixedMessage(sender, "&4This editor can only be opened by a player.");
+                return;
+            }
+            typeEditService.openEditor(player, typeId);
+        }
+
         @Subcommand("type")
         @CommandPermission(Permissions.Admin.Edit.EDIT_CUSTOM_TYPE)
         @CommandCompletion("@custom-types @edit-type @edit-type-value") //Default Types needs to depend on edit-types

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/edit/CardEditService.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/edit/CardEditService.java
@@ -20,8 +20,10 @@ import net.tinetwork.tradingcards.tradingcardsplugin.messages.internal.InternalM
 import net.tinetwork.tradingcards.tradingcardsplugin.utils.ChatUtil;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public final class CardEditService {
@@ -237,6 +239,20 @@ public final class CardEditService {
                                         player.showDialog(buildInfoEditor(getCard(card.getRarity().getId(), card.getSeries().getId(), card.getCardId())));
                                     }
                                 }, ClickCallback.Options.builder().uses(1).build())
+                        ),
+                        ActionButton.create(
+                                Component.text("Preview Item"),
+                                Component.text("Preview the current card item"),
+                                120,
+                                DialogAction.customClick((response, audience) -> {
+                                    if (audience instanceof Player player) {
+                                        player.showDialog(buildPreviewDialog(
+                                                "Card preview: " + card.getCardId(),
+                                                getCard(card.getRarity().getId(), card.getSeries().getId(), card.getCardId()),
+                                                previewPlayer -> previewPlayer.showDialog(buildEditorMenu(getCard(card.getRarity().getId(), card.getSeries().getId(), card.getCardId())))
+                                        ));
+                                    }
+                                }, ClickCallback.Options.builder().uses(1).build())
                         )
                 ), null, 2)));
     }
@@ -255,7 +271,7 @@ public final class CardEditService {
                         ))
                         .canCloseWithEscape(true)
                         .build())
-                .type(DialogType.confirmation(
+                .type(DialogType.multiAction(List.of(
                         ActionButton.create(
                                 Component.text("Save Details"),
                                 Component.text("Apply these detail edits"),
@@ -275,8 +291,32 @@ public final class CardEditService {
                                     }
                                 }, ClickCallback.Options.builder().uses(1).build())
                         ),
+                        ActionButton.create(
+                                Component.text("Preview"),
+                                Component.text("Preview the card item with these values"),
+                                120,
+                                DialogAction.customClick((response, audience) -> {
+                                    if (audience instanceof Player player) {
+                                        final TradingCard previewCard = buildDetailsPreviewCard(
+                                                player,
+                                                card,
+                                                textValue(response.getText(DISPLAY_NAME_KEY)),
+                                                textValue(response.getText(TYPE_KEY)),
+                                                textValue(response.getText(SERIES_KEY)),
+                                                textValue(response.getText(HAS_SHINY_KEY))
+                                        );
+                                        if (previewCard != null) {
+                                            player.showDialog(buildPreviewDialog(
+                                                    "Card preview: " + card.getCardId(),
+                                                    previewCard,
+                                                    previewPlayer -> previewPlayer.showDialog(buildDetailsEditor(getCard(card.getRarity().getId(), card.getSeries().getId(), card.getCardId())))
+                                            ));
+                                        }
+                                    }
+                                }, ClickCallback.Options.builder().uses(1).build())
+                        ),
                         ActionButton.create(Component.text("Cancel"), Component.text("Discard these changes"), 120, null)
-                )));
+                ), null, 2)));
     }
 
     private @NotNull Dialog buildEconomyEditor(final @NotNull TradingCard card) {
@@ -293,7 +333,7 @@ public final class CardEditService {
                         ))
                         .canCloseWithEscape(true)
                         .build())
-                .type(DialogType.confirmation(
+                .type(DialogType.multiAction(List.of(
                         ActionButton.create(
                                 Component.text("Save Economy"),
                                 Component.text("Apply these economy edits"),
@@ -313,8 +353,32 @@ public final class CardEditService {
                                     }
                                 }, ClickCallback.Options.builder().uses(1).build())
                         ),
+                        ActionButton.create(
+                                Component.text("Preview"),
+                                Component.text("Preview the card item with these values"),
+                                120,
+                                DialogAction.customClick((response, audience) -> {
+                                    if (audience instanceof Player player) {
+                                        final TradingCard previewCard = buildEconomyPreviewCard(
+                                                player,
+                                                card,
+                                                textValue(response.getText(BUY_PRICE_KEY)),
+                                                textValue(response.getText(SELL_PRICE_KEY)),
+                                                textValue(response.getText(CURRENCY_ID_KEY)),
+                                                textValue(response.getText(CUSTOM_MODEL_DATA_KEY))
+                                        );
+                                        if (previewCard != null) {
+                                            player.showDialog(buildPreviewDialog(
+                                                    "Card preview: " + card.getCardId(),
+                                                    previewCard,
+                                                    previewPlayer -> previewPlayer.showDialog(buildEconomyEditor(getCard(card.getRarity().getId(), card.getSeries().getId(), card.getCardId())))
+                                            ));
+                                        }
+                                    }
+                                }, ClickCallback.Options.builder().uses(1).build())
+                        ),
                         ActionButton.create(Component.text("Cancel"), Component.text("Discard these changes"), 120, null)
-                )));
+                ), null, 2)));
     }
 
     private @NotNull Dialog buildInfoEditor(final @NotNull TradingCard card) {
@@ -333,7 +397,7 @@ public final class CardEditService {
                         ))
                         .canCloseWithEscape(true)
                         .build())
-                .type(DialogType.confirmation(
+                .type(DialogType.multiAction(List.of(
                         ActionButton.create(
                                 Component.text("Save Info"),
                                 Component.text("Apply these info edits"),
@@ -350,8 +414,126 @@ public final class CardEditService {
                                     }
                                 }, ClickCallback.Options.builder().uses(1).build())
                         ),
+                        ActionButton.create(
+                                Component.text("Preview"),
+                                Component.text("Preview the card item with these values"),
+                                120,
+                                DialogAction.customClick((response, audience) -> {
+                                    if (audience instanceof Player player) {
+                                        player.showDialog(buildPreviewDialog(
+                                                "Card preview: " + card.getCardId(),
+                                                buildInfoPreviewCard(card, textValue(response.getText(INFO_KEY))),
+                                                previewPlayer -> previewPlayer.showDialog(buildInfoEditor(getCard(card.getRarity().getId(), card.getSeries().getId(), card.getCardId())))
+                                        ));
+                                    }
+                                }, ClickCallback.Options.builder().uses(1).build())
+                        ),
                         ActionButton.create(Component.text("Cancel"), Component.text("Discard these changes"), 120, null)
-                )));
+                ), null, 2)));
+    }
+
+    private TradingCard buildDetailsPreviewCard(
+            final @NotNull CommandSender sender,
+            final @NotNull TradingCard card,
+            final @NotNull String displayName,
+            final @NotNull String typeId,
+            final @NotNull String targetSeriesId,
+            final @NotNull String hasShinyInput
+    ) {
+        if (!plugin.getDropTypeManager().containsType(typeId)) {
+            ChatUtil.sendPrefixedMessage(sender, InternalMessages.NO_TYPE.formatted(typeId));
+            return null;
+        }
+        if (!plugin.getSeriesManager().containsSeries(targetSeriesId)) {
+            ChatUtil.sendPrefixedMessage(sender, InternalMessages.NO_SERIES.formatted(targetSeriesId));
+            return null;
+        }
+
+        final Boolean hasShiny = parseBoolean(hasShinyInput);
+        if (hasShiny == null) {
+            ChatUtil.sendPrefixedMessage(sender, "&4Has shiny must be &ctrue &4or &cfalse");
+            return null;
+        }
+
+        final TradingCard previewCard = new TradingCard(card);
+        previewCard.displayName(displayName)
+                .type(plugin.getDropTypeManager().getType(typeId))
+                .series(plugin.getSeriesManager().getSeries(targetSeriesId))
+                .hasShiny(hasShiny);
+        return previewCard;
+    }
+
+    private TradingCard buildEconomyPreviewCard(
+            final @NotNull CommandSender sender,
+            final @NotNull TradingCard card,
+            final @NotNull String buyPriceInput,
+            final @NotNull String sellPriceInput,
+            final @NotNull String currencyId,
+            final @NotNull String customModelDataInput
+    ) {
+        final double buyPrice = parsePrice(buyPriceInput);
+        final double sellPrice = parsePrice(sellPriceInput);
+        if (buyPrice <= -1.00D || sellPrice <= -1.00D) {
+            ChatUtil.sendPrefixedMessage(sender, InternalMessages.EditCommand.PRICE_INCORRECT);
+            return null;
+        }
+
+        final int customModelData = parseCustomModelData(customModelDataInput);
+        if (customModelData < 0) {
+            ChatUtil.sendPrefixedMessage(sender, InternalMessages.EditCommand.CUSTOM_MODEL_DATA_INCORRECT);
+            return null;
+        }
+
+        final TradingCard previewCard = new TradingCard(card);
+        previewCard.buyPrice(buyPrice)
+                .sellPrice(sellPrice)
+                .currencyId(currencyId)
+                .customModelNbt(customModelData);
+        return previewCard;
+    }
+
+    private @NotNull TradingCard buildInfoPreviewCard(final @NotNull TradingCard card, final @NotNull String info) {
+        final TradingCard previewCard = new TradingCard(card);
+        previewCard.info(info);
+        return previewCard;
+    }
+
+    private @NotNull Dialog buildPreviewDialog(
+            final @NotNull String title,
+            final @NotNull TradingCard card,
+            final @NotNull PreviewReturn previewReturn
+    ) {
+        final List<DialogBody> body = new ArrayList<>();
+        body.add(DialogBody.plainMessage(Component.text("Previewing the resulting card item."), 340));
+        body.add(DialogBody.plainMessage(Component.text("Display: " + card.getDisplayName() + " | Type: " + card.getType().getId()), 340));
+        body.add(DialogBody.plainMessage(Component.text("Series: " + card.getSeries().getId() + " | Has shiny: " + card.hasShiny()), 340));
+        body.add(DialogBody.plainMessage(Component.text("Normal"), 340));
+        body.add(DialogBody.item(safeBuild(card, false)).build());
+        if (card.hasShiny()) {
+            body.add(DialogBody.plainMessage(Component.text("Shiny"), 340));
+            body.add(DialogBody.item(safeBuild(card, true)).build());
+        }
+
+        return Dialog.create(builder -> builder.empty()
+                .base(DialogBase.builder(Component.text(title))
+                        .body(body)
+                        .build())
+                .type(DialogType.multiAction(List.of(
+                        ActionButton.create(
+                                Component.text("Back"),
+                                Component.text("Return to the editor"),
+                                120,
+                                DialogAction.customClick((response, audience) -> {
+                                    if (audience instanceof Player player) {
+                                        previewReturn.show(player);
+                                    }
+                                }, ClickCallback.Options.builder().uses(1).build())
+                        )
+                ), null, 1)));
+    }
+
+    private @NotNull ItemStack safeBuild(final @NotNull TradingCard card, final boolean shiny) {
+        return card.build(shiny);
     }
 
     private void reopenEditor(final @NotNull CommandSender sender, final @NotNull String rarityId, final @NotNull String seriesId, final @NotNull String cardId) {
@@ -396,5 +578,10 @@ public final class CardEditService {
 
     private @NotNull String orEmpty(final String input) {
         return input == null ? "" : input;
+    }
+
+    @FunctionalInterface
+    private interface PreviewReturn {
+        void show(Player player);
     }
 }

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/edit/CardEditService.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/edit/CardEditService.java
@@ -197,7 +197,7 @@ public final class CardEditService {
                 .base(DialogBase.builder(Component.text("Edit card: " + card.getCardId()))
                         .body(List.of(
                                 DialogBody.plainMessage(Component.text("Rarity: " + card.getRarity().getId() + " | Series: " + card.getSeries().getId()), 340),
-                                DialogBody.plainMessage(Component.text("Display: " + card.getDisplayName()), 340),
+                                DialogBody.plainMessage(Component.text("Display: ").append(ChatUtil.component(card.getDisplayName())), 340),
                                 DialogBody.plainMessage(Component.text("Type: " + card.getType().getId() + " | Has shiny: " + card.hasShiny()), 340),
                                 DialogBody.plainMessage(Component.text("Buy: " + card.getBuyPrice() + " | Sell: " + card.getSellPrice() + " | Currency: " + orEmpty(card.getCurrencyId())), 340),
                                 DialogBody.plainMessage(Component.text("Model data: " + card.getCustomModelNbt()), 340),
@@ -494,7 +494,7 @@ public final class CardEditService {
     ) {
         final List<DialogBody> body = new ArrayList<>();
         body.add(DialogBody.plainMessage(Component.text("Previewing the resulting card item."), 340));
-        body.add(DialogBody.plainMessage(Component.text("Display: " + card.getDisplayName() + " | Type: " + card.getType().getId()), 340));
+        body.add(DialogBody.plainMessage(Component.text("Display: ").append(ChatUtil.component(card.getDisplayName())).append(Component.text(" | Type: " + card.getType().getId())), 340));
         body.add(DialogBody.plainMessage(Component.text("Series: " + card.getSeries().getId() + " | Has shiny: " + card.hasShiny()), 340));
         body.add(DialogBody.plainMessage(Component.text("Normal"), 340));
         body.add(DialogBody.item(safeBuild(card, false)).build());
@@ -539,7 +539,7 @@ public final class CardEditService {
         return plugin.getSeriesManager().getAllSeries().stream()
                 .map(series -> SingleOptionDialogInput.OptionEntry.create(
                         series.getId(),
-                        Component.text(series.getDisplayName() + " (" + series.getId() + ")"),
+                        ChatUtil.component(series.getDisplayName()).append(Component.text(" (" + series.getId() + ")")),
                         series.getId().equals(selectedSeriesId)
                 ))
                 .toList();
@@ -549,7 +549,7 @@ public final class CardEditService {
         return plugin.getDropTypeManager().getTypes().values().stream()
                 .map(type -> SingleOptionDialogInput.OptionEntry.create(
                         type.getId(),
-                        Component.text(type.getDisplayName() + " (" + type.getId() + ")"),
+                        ChatUtil.component(type.getDisplayName()).append(Component.text(" (" + type.getId() + ")")),
                         type.getId().equals(selectedTypeId)
                 ))
                 .toList();

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/edit/CardEditService.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/edit/CardEditService.java
@@ -6,6 +6,7 @@ import io.papermc.paper.registry.data.dialog.DialogBase;
 import io.papermc.paper.registry.data.dialog.action.DialogAction;
 import io.papermc.paper.registry.data.dialog.body.DialogBody;
 import io.papermc.paper.registry.data.dialog.input.DialogInput;
+import io.papermc.paper.registry.data.dialog.input.SingleOptionDialogInput;
 import io.papermc.paper.registry.data.dialog.input.TextDialogInput;
 import io.papermc.paper.registry.data.dialog.type.DialogType;
 import net.kyori.adventure.text.Component;
@@ -55,7 +56,7 @@ public final class CardEditService {
             final @NotNull String displayName,
             final @NotNull String typeId,
             final @NotNull String targetSeriesId,
-            final @NotNull String hasShinyInput
+            final boolean hasShiny
     ) {
         final TradingCard card = getCard(rarityId, seriesId, cardId);
         if (!plugin.getDropTypeManager().containsType(typeId)) {
@@ -68,12 +69,6 @@ public final class CardEditService {
         }
         if (!seriesId.equals(targetSeriesId) && plugin.getCardManager().containsCard(cardId, rarityId, targetSeriesId)) {
             ChatUtil.sendPrefixedMessage(sender, "&4Card already exists for &c%s".formatted("%s, %s, %s".formatted(cardId, rarityId, targetSeriesId)));
-            return false;
-        }
-
-        final Boolean hasShiny = parseBoolean(hasShinyInput);
-        if (hasShiny == null) {
-            ChatUtil.sendPrefixedMessage(sender, "&4Has shiny must be &ctrue &4or &cfalse");
             return false;
         }
 
@@ -265,9 +260,9 @@ public final class CardEditService {
                         ))
                         .inputs(List.of(
                                 DialogInput.text(DISPLAY_NAME_KEY, Component.text("Display Name")).initial(card.getDisplayName()).maxLength(128).width(340).build(),
-                                DialogInput.text(TYPE_KEY, Component.text("Type Id")).initial(card.getType().getId()).maxLength(128).width(340).build(),
-                                DialogInput.text(SERIES_KEY, Component.text("Series Id")).initial(card.getSeries().getId()).maxLength(128).width(340).build(),
-                                DialogInput.text(HAS_SHINY_KEY, Component.text("Has Shiny")).initial(String.valueOf(card.hasShiny())).maxLength(16).width(340).build()
+                                DialogInput.singleOption(TYPE_KEY, Component.text("Type"), buildTypeOptions(card.getType().getId())).width(340).build(),
+                                DialogInput.singleOption(SERIES_KEY, Component.text("Series"), buildSeriesOptions(card.getSeries().getId())).width(340).build(),
+                                DialogInput.bool(HAS_SHINY_KEY, Component.text("Has Shiny"), card.hasShiny(), "true", "false")
                         ))
                         .canCloseWithEscape(true)
                         .build())
@@ -286,7 +281,7 @@ public final class CardEditService {
                                                 textValue(response.getText(DISPLAY_NAME_KEY)),
                                                 textValue(response.getText(TYPE_KEY)),
                                                 textValue(response.getText(SERIES_KEY)),
-                                                textValue(response.getText(HAS_SHINY_KEY))
+                                                booleanValue(response.getBoolean(HAS_SHINY_KEY), card.hasShiny())
                                         );
                                     }
                                 }, ClickCallback.Options.builder().uses(1).build())
@@ -303,7 +298,7 @@ public final class CardEditService {
                                                 textValue(response.getText(DISPLAY_NAME_KEY)),
                                                 textValue(response.getText(TYPE_KEY)),
                                                 textValue(response.getText(SERIES_KEY)),
-                                                textValue(response.getText(HAS_SHINY_KEY))
+                                                booleanValue(response.getBoolean(HAS_SHINY_KEY), card.hasShiny())
                                         );
                                         if (previewCard != null) {
                                             player.showDialog(buildPreviewDialog(
@@ -438,7 +433,7 @@ public final class CardEditService {
             final @NotNull String displayName,
             final @NotNull String typeId,
             final @NotNull String targetSeriesId,
-            final @NotNull String hasShinyInput
+            final boolean hasShiny
     ) {
         if (!plugin.getDropTypeManager().containsType(typeId)) {
             ChatUtil.sendPrefixedMessage(sender, InternalMessages.NO_TYPE.formatted(typeId));
@@ -446,12 +441,6 @@ public final class CardEditService {
         }
         if (!plugin.getSeriesManager().containsSeries(targetSeriesId)) {
             ChatUtil.sendPrefixedMessage(sender, InternalMessages.NO_SERIES.formatted(targetSeriesId));
-            return null;
-        }
-
-        final Boolean hasShiny = parseBoolean(hasShinyInput);
-        if (hasShiny == null) {
-            ChatUtil.sendPrefixedMessage(sender, "&4Has shiny must be &ctrue &4or &cfalse");
             return null;
         }
 
@@ -546,6 +535,26 @@ public final class CardEditService {
         return plugin.getStorage().getCard(cardId, rarityId, seriesId).get();
     }
 
+    private @NotNull List<SingleOptionDialogInput.OptionEntry> buildSeriesOptions(final @NotNull String selectedSeriesId) {
+        return plugin.getSeriesManager().getAllSeries().stream()
+                .map(series -> SingleOptionDialogInput.OptionEntry.create(
+                        series.getId(),
+                        Component.text(series.getDisplayName() + " (" + series.getId() + ")"),
+                        series.getId().equals(selectedSeriesId)
+                ))
+                .toList();
+    }
+
+    private @NotNull List<SingleOptionDialogInput.OptionEntry> buildTypeOptions(final @NotNull String selectedTypeId) {
+        return plugin.getDropTypeManager().getTypes().values().stream()
+                .map(type -> SingleOptionDialogInput.OptionEntry.create(
+                        type.getId(),
+                        Component.text(type.getDisplayName() + " (" + type.getId() + ")"),
+                        type.getId().equals(selectedTypeId)
+                ))
+                .toList();
+    }
+
     private double parsePrice(final @NotNull String input) {
         try {
             return Double.parseDouble(input);
@@ -562,18 +571,12 @@ public final class CardEditService {
         }
     }
 
-    private Boolean parseBoolean(final @NotNull String input) {
-        if ("true".equalsIgnoreCase(input)) {
-            return true;
-        }
-        if ("false".equalsIgnoreCase(input)) {
-            return false;
-        }
-        return null;
-    }
-
     private @NotNull String textValue(final String input) {
         return input == null ? "" : input.trim();
+    }
+
+    private boolean booleanValue(final Boolean input, final boolean fallback) {
+        return input == null ? fallback : input;
     }
 
     private @NotNull String orEmpty(final String input) {

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/edit/CardEditService.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/edit/CardEditService.java
@@ -1,0 +1,400 @@
+package net.tinetwork.tradingcards.tradingcardsplugin.commands.edit;
+
+import io.papermc.paper.dialog.Dialog;
+import io.papermc.paper.registry.data.dialog.ActionButton;
+import io.papermc.paper.registry.data.dialog.DialogBase;
+import io.papermc.paper.registry.data.dialog.action.DialogAction;
+import io.papermc.paper.registry.data.dialog.body.DialogBody;
+import io.papermc.paper.registry.data.dialog.input.DialogInput;
+import io.papermc.paper.registry.data.dialog.input.TextDialogInput;
+import io.papermc.paper.registry.data.dialog.type.DialogType;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickCallback;
+import net.tinetwork.tradingcards.api.model.DropType;
+import net.tinetwork.tradingcards.api.model.Series;
+import net.tinetwork.tradingcards.tradingcardsplugin.TradingCards;
+import net.tinetwork.tradingcards.tradingcardsplugin.card.TradingCard;
+import net.tinetwork.tradingcards.tradingcardsplugin.managers.cards.CompositeCardKey;
+import net.tinetwork.tradingcards.tradingcardsplugin.managers.cards.CompositeRaritySeriesKey;
+import net.tinetwork.tradingcards.tradingcardsplugin.messages.internal.InternalMessages;
+import net.tinetwork.tradingcards.tradingcardsplugin.utils.ChatUtil;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public final class CardEditService {
+    private static final String DISPLAY_NAME_KEY = "display_name";
+    private static final String TYPE_KEY = "type";
+    private static final String SERIES_KEY = "series";
+    private static final String HAS_SHINY_KEY = "has_shiny";
+    private static final String BUY_PRICE_KEY = "buy_price";
+    private static final String SELL_PRICE_KEY = "sell_price";
+    private static final String CURRENCY_ID_KEY = "currency_id";
+    private static final String CUSTOM_MODEL_DATA_KEY = "custom_model_data";
+    private static final String INFO_KEY = "info";
+
+    private final TradingCards plugin;
+
+    public CardEditService(final @NotNull TradingCards plugin) {
+        this.plugin = plugin;
+    }
+
+    public void openEditor(final @NotNull Player player, final @NotNull String rarityId, final @NotNull String seriesId, final @NotNull String cardId) {
+        player.showDialog(buildEditorMenu(getCard(rarityId, seriesId, cardId)));
+    }
+
+    public boolean applyDetailsEdits(
+            final @NotNull CommandSender sender,
+            final @NotNull String rarityId,
+            final @NotNull String seriesId,
+            final @NotNull String cardId,
+            final @NotNull String displayName,
+            final @NotNull String typeId,
+            final @NotNull String targetSeriesId,
+            final @NotNull String hasShinyInput
+    ) {
+        final TradingCard card = getCard(rarityId, seriesId, cardId);
+        if (!plugin.getDropTypeManager().containsType(typeId)) {
+            ChatUtil.sendPrefixedMessage(sender, InternalMessages.NO_TYPE.formatted(typeId));
+            return false;
+        }
+        if (!plugin.getSeriesManager().containsSeries(targetSeriesId)) {
+            ChatUtil.sendPrefixedMessage(sender, InternalMessages.NO_SERIES.formatted(targetSeriesId));
+            return false;
+        }
+        if (!seriesId.equals(targetSeriesId) && plugin.getCardManager().containsCard(cardId, rarityId, targetSeriesId)) {
+            ChatUtil.sendPrefixedMessage(sender, "&4Card already exists for &c%s".formatted("%s, %s, %s".formatted(cardId, rarityId, targetSeriesId)));
+            return false;
+        }
+
+        final Boolean hasShiny = parseBoolean(hasShinyInput);
+        if (hasShiny == null) {
+            ChatUtil.sendPrefixedMessage(sender, "&4Has shiny must be &ctrue &4or &cfalse");
+            return false;
+        }
+
+        final DropType type = plugin.getDropTypeManager().getType(typeId);
+        final Series targetSeries = plugin.getSeriesManager().getSeries(targetSeriesId);
+        plugin.getStorage().editCard(
+                rarityId,
+                cardId,
+                seriesId,
+                displayName,
+                targetSeries,
+                type,
+                card.getInfo(),
+                card.getCustomModelNbt(),
+                card.getBuyPrice(),
+                card.getSellPrice(),
+                hasShiny,
+                orEmpty(card.getCurrencyId())
+        );
+        refreshCardCaches(rarityId, cardId, seriesId, targetSeriesId);
+        ChatUtil.sendPrefixedMessage(sender, "&7Updated &bdetails &7for &b%s".formatted(cardId));
+        reopenEditor(sender, rarityId, targetSeriesId, cardId);
+        return true;
+    }
+
+    public boolean applyEconomyEdits(
+            final @NotNull CommandSender sender,
+            final @NotNull String rarityId,
+            final @NotNull String seriesId,
+            final @NotNull String cardId,
+            final @NotNull String buyPriceInput,
+            final @NotNull String sellPriceInput,
+            final @NotNull String currencyId,
+            final @NotNull String customModelDataInput
+    ) {
+        final TradingCard card = getCard(rarityId, seriesId, cardId);
+        final double buyPrice = parsePrice(buyPriceInput);
+        final double sellPrice = parsePrice(sellPriceInput);
+        if (buyPrice <= -1.00D || sellPrice <= -1.00D) {
+            ChatUtil.sendPrefixedMessage(sender, InternalMessages.EditCommand.PRICE_INCORRECT);
+            return false;
+        }
+
+        final int customModelData = parseCustomModelData(customModelDataInput);
+        if (customModelData < 0) {
+            ChatUtil.sendPrefixedMessage(sender, InternalMessages.EditCommand.CUSTOM_MODEL_DATA_INCORRECT);
+            return false;
+        }
+
+        plugin.getStorage().editCard(
+                rarityId,
+                cardId,
+                seriesId,
+                card.getDisplayName(),
+                card.getSeries(),
+                card.getType(),
+                card.getInfo(),
+                customModelData,
+                buyPrice,
+                sellPrice,
+                card.hasShiny(),
+                currencyId
+        );
+        refreshCardCaches(rarityId, cardId, seriesId, seriesId);
+        ChatUtil.sendPrefixedMessage(sender, "&7Updated &beconomy &7for &b%s".formatted(cardId));
+        reopenEditor(sender, rarityId, seriesId, cardId);
+        return true;
+    }
+
+    public boolean applyInfoEdits(
+            final @NotNull CommandSender sender,
+            final @NotNull String rarityId,
+            final @NotNull String seriesId,
+            final @NotNull String cardId,
+            final @NotNull String info
+    ) {
+        final TradingCard card = getCard(rarityId, seriesId, cardId);
+        plugin.getStorage().editCard(
+                rarityId,
+                cardId,
+                seriesId,
+                card.getDisplayName(),
+                card.getSeries(),
+                card.getType(),
+                info,
+                card.getCustomModelNbt(),
+                card.getBuyPrice(),
+                card.getSellPrice(),
+                card.hasShiny(),
+                orEmpty(card.getCurrencyId())
+        );
+        refreshCardCaches(rarityId, cardId, seriesId, seriesId);
+        ChatUtil.sendPrefixedMessage(sender, "&7Updated &binfo &7for &b%s".formatted(cardId));
+        reopenEditor(sender, rarityId, seriesId, cardId);
+        return true;
+    }
+
+    public void refreshCardCaches(final @NotNull String rarityId, final @NotNull String cardId, final @NotNull String oldSeriesId, final @NotNull String newSeriesId) {
+        final CompositeCardKey oldKey = new CompositeCardKey(rarityId, oldSeriesId, cardId);
+        final CompositeCardKey newKey = new CompositeCardKey(rarityId, newSeriesId, cardId);
+
+        plugin.getCardManager().getCache().invalidate(oldKey);
+        plugin.getCardManager().getCache().invalidate(newKey);
+        plugin.getCardManager().getCache().refresh(newKey);
+
+        plugin.getCardManager().getRarityCardCache().invalidate(rarityId);
+        plugin.getCardManager().getRarityCardCache().refresh(rarityId);
+
+        refreshSeriesCaches(rarityId, oldSeriesId);
+        if (!oldSeriesId.equals(newSeriesId)) {
+            refreshSeriesCaches(rarityId, newSeriesId);
+        }
+    }
+
+    private void refreshSeriesCaches(final @NotNull String rarityId, final @NotNull String seriesId) {
+        plugin.getCardManager().getSeriesCardCache().invalidate(seriesId);
+        plugin.getCardManager().getSeriesCardCache().refresh(seriesId);
+
+        final CompositeRaritySeriesKey raritySeriesKey = CompositeRaritySeriesKey.of(rarityId, seriesId);
+        plugin.getCardManager().getRarityAndSeriesCardCache().invalidate(raritySeriesKey);
+        plugin.getCardManager().getRarityAndSeriesCardCache().refresh(raritySeriesKey);
+    }
+
+    private @NotNull Dialog buildEditorMenu(final @NotNull TradingCard card) {
+        return Dialog.create(builder -> builder.empty()
+                .base(DialogBase.builder(Component.text("Edit card: " + card.getCardId()))
+                        .body(List.of(
+                                DialogBody.plainMessage(Component.text("Rarity: " + card.getRarity().getId() + " | Series: " + card.getSeries().getId()), 340),
+                                DialogBody.plainMessage(Component.text("Display: " + card.getDisplayName()), 340),
+                                DialogBody.plainMessage(Component.text("Type: " + card.getType().getId() + " | Has shiny: " + card.hasShiny()), 340),
+                                DialogBody.plainMessage(Component.text("Buy: " + card.getBuyPrice() + " | Sell: " + card.getSellPrice() + " | Currency: " + orEmpty(card.getCurrencyId())), 340),
+                                DialogBody.plainMessage(Component.text("Model data: " + card.getCustomModelNbt()), 340),
+                                DialogBody.plainMessage(Component.text("Choose which part of the card to edit."), 340)
+                        ))
+                        .build())
+                .type(DialogType.multiAction(List.of(
+                        ActionButton.create(
+                                Component.text("Edit Details"),
+                                Component.text("Display name, type, series and shiny"),
+                                120,
+                                DialogAction.customClick((response, audience) -> {
+                                    if (audience instanceof Player player) {
+                                        player.showDialog(buildDetailsEditor(getCard(card.getRarity().getId(), card.getSeries().getId(), card.getCardId())));
+                                    }
+                                }, ClickCallback.Options.builder().uses(1).build())
+                        ),
+                        ActionButton.create(
+                                Component.text("Edit Economy"),
+                                Component.text("Prices, currency and model data"),
+                                120,
+                                DialogAction.customClick((response, audience) -> {
+                                    if (audience instanceof Player player) {
+                                        player.showDialog(buildEconomyEditor(getCard(card.getRarity().getId(), card.getSeries().getId(), card.getCardId())));
+                                    }
+                                }, ClickCallback.Options.builder().uses(1).build())
+                        ),
+                        ActionButton.create(
+                                Component.text("Edit Info"),
+                                Component.text("Card lore text"),
+                                120,
+                                DialogAction.customClick((response, audience) -> {
+                                    if (audience instanceof Player player) {
+                                        player.showDialog(buildInfoEditor(getCard(card.getRarity().getId(), card.getSeries().getId(), card.getCardId())));
+                                    }
+                                }, ClickCallback.Options.builder().uses(1).build())
+                        )
+                ), null, 2)));
+    }
+
+    private @NotNull Dialog buildDetailsEditor(final @NotNull TradingCard card) {
+        return Dialog.create(builder -> builder.empty()
+                .base(DialogBase.builder(Component.text("Edit details: " + card.getCardId()))
+                        .body(List.of(
+                                DialogBody.plainMessage(Component.text("Has shiny accepts true or false."), 340)
+                        ))
+                        .inputs(List.of(
+                                DialogInput.text(DISPLAY_NAME_KEY, Component.text("Display Name")).initial(card.getDisplayName()).maxLength(128).width(340).build(),
+                                DialogInput.text(TYPE_KEY, Component.text("Type Id")).initial(card.getType().getId()).maxLength(128).width(340).build(),
+                                DialogInput.text(SERIES_KEY, Component.text("Series Id")).initial(card.getSeries().getId()).maxLength(128).width(340).build(),
+                                DialogInput.text(HAS_SHINY_KEY, Component.text("Has Shiny")).initial(String.valueOf(card.hasShiny())).maxLength(16).width(340).build()
+                        ))
+                        .canCloseWithEscape(true)
+                        .build())
+                .type(DialogType.confirmation(
+                        ActionButton.create(
+                                Component.text("Save Details"),
+                                Component.text("Apply these detail edits"),
+                                120,
+                                DialogAction.customClick((response, audience) -> {
+                                    if (audience instanceof Player player) {
+                                        applyDetailsEdits(
+                                                player,
+                                                card.getRarity().getId(),
+                                                card.getSeries().getId(),
+                                                card.getCardId(),
+                                                textValue(response.getText(DISPLAY_NAME_KEY)),
+                                                textValue(response.getText(TYPE_KEY)),
+                                                textValue(response.getText(SERIES_KEY)),
+                                                textValue(response.getText(HAS_SHINY_KEY))
+                                        );
+                                    }
+                                }, ClickCallback.Options.builder().uses(1).build())
+                        ),
+                        ActionButton.create(Component.text("Cancel"), Component.text("Discard these changes"), 120, null)
+                )));
+    }
+
+    private @NotNull Dialog buildEconomyEditor(final @NotNull TradingCard card) {
+        return Dialog.create(builder -> builder.empty()
+                .base(DialogBase.builder(Component.text("Edit economy: " + card.getCardId()))
+                        .body(List.of(
+                                DialogBody.plainMessage(Component.text("Custom model data can be 0 or greater."), 340)
+                        ))
+                        .inputs(List.of(
+                                DialogInput.text(BUY_PRICE_KEY, Component.text("Buy Price")).initial(String.valueOf(card.getBuyPrice())).maxLength(32).width(340).build(),
+                                DialogInput.text(SELL_PRICE_KEY, Component.text("Sell Price")).initial(String.valueOf(card.getSellPrice())).maxLength(32).width(340).build(),
+                                DialogInput.text(CURRENCY_ID_KEY, Component.text("Currency Id")).initial(orEmpty(card.getCurrencyId())).maxLength(128).width(340).build(),
+                                DialogInput.text(CUSTOM_MODEL_DATA_KEY, Component.text("Custom Model Data")).initial(String.valueOf(card.getCustomModelNbt())).maxLength(32).width(340).build()
+                        ))
+                        .canCloseWithEscape(true)
+                        .build())
+                .type(DialogType.confirmation(
+                        ActionButton.create(
+                                Component.text("Save Economy"),
+                                Component.text("Apply these economy edits"),
+                                120,
+                                DialogAction.customClick((response, audience) -> {
+                                    if (audience instanceof Player player) {
+                                        applyEconomyEdits(
+                                                player,
+                                                card.getRarity().getId(),
+                                                card.getSeries().getId(),
+                                                card.getCardId(),
+                                                textValue(response.getText(BUY_PRICE_KEY)),
+                                                textValue(response.getText(SELL_PRICE_KEY)),
+                                                textValue(response.getText(CURRENCY_ID_KEY)),
+                                                textValue(response.getText(CUSTOM_MODEL_DATA_KEY))
+                                        );
+                                    }
+                                }, ClickCallback.Options.builder().uses(1).build())
+                        ),
+                        ActionButton.create(Component.text("Cancel"), Component.text("Discard these changes"), 120, null)
+                )));
+    }
+
+    private @NotNull Dialog buildInfoEditor(final @NotNull TradingCard card) {
+        return Dialog.create(builder -> builder.empty()
+                .base(DialogBase.builder(Component.text("Edit info: " + card.getCardId()))
+                        .body(List.of(
+                                DialogBody.plainMessage(Component.text("This updates the card info text shown in lore."), 340)
+                        ))
+                        .inputs(List.of(
+                                DialogInput.text(INFO_KEY, Component.text("Info"))
+                                        .initial(orEmpty(card.getInfo()))
+                                        .maxLength(4096)
+                                        .width(340)
+                                        .multiline(TextDialogInput.MultilineOptions.create(8, 160))
+                                        .build()
+                        ))
+                        .canCloseWithEscape(true)
+                        .build())
+                .type(DialogType.confirmation(
+                        ActionButton.create(
+                                Component.text("Save Info"),
+                                Component.text("Apply these info edits"),
+                                120,
+                                DialogAction.customClick((response, audience) -> {
+                                    if (audience instanceof Player player) {
+                                        applyInfoEdits(
+                                                player,
+                                                card.getRarity().getId(),
+                                                card.getSeries().getId(),
+                                                card.getCardId(),
+                                                textValue(response.getText(INFO_KEY))
+                                        );
+                                    }
+                                }, ClickCallback.Options.builder().uses(1).build())
+                        ),
+                        ActionButton.create(Component.text("Cancel"), Component.text("Discard these changes"), 120, null)
+                )));
+    }
+
+    private void reopenEditor(final @NotNull CommandSender sender, final @NotNull String rarityId, final @NotNull String seriesId, final @NotNull String cardId) {
+        if (sender instanceof Player player) {
+            player.showDialog(buildEditorMenu(getCard(rarityId, seriesId, cardId)));
+        }
+    }
+
+    private @NotNull TradingCard getCard(final @NotNull String rarityId, final @NotNull String seriesId, final @NotNull String cardId) {
+        return plugin.getStorage().getCard(cardId, rarityId, seriesId).get();
+    }
+
+    private double parsePrice(final @NotNull String input) {
+        try {
+            return Double.parseDouble(input);
+        } catch (NumberFormatException ignored) {
+            return -1.00D;
+        }
+    }
+
+    private int parseCustomModelData(final @NotNull String input) {
+        try {
+            return Integer.parseInt(input);
+        } catch (NumberFormatException ignored) {
+            return -1;
+        }
+    }
+
+    private Boolean parseBoolean(final @NotNull String input) {
+        if ("true".equalsIgnoreCase(input)) {
+            return true;
+        }
+        if ("false".equalsIgnoreCase(input)) {
+            return false;
+        }
+        return null;
+    }
+
+    private @NotNull String textValue(final String input) {
+        return input == null ? "" : input.trim();
+    }
+
+    private @NotNull String orEmpty(final String input) {
+        return input == null ? "" : input;
+    }
+}

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/edit/PackEditService.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/edit/PackEditService.java
@@ -1,0 +1,365 @@
+package net.tinetwork.tradingcards.tradingcardsplugin.commands.edit;
+
+import io.papermc.paper.dialog.Dialog;
+import io.papermc.paper.registry.data.dialog.ActionButton;
+import io.papermc.paper.registry.data.dialog.DialogBase;
+import io.papermc.paper.registry.data.dialog.body.DialogBody;
+import io.papermc.paper.registry.data.dialog.input.DialogInput;
+import io.papermc.paper.registry.data.dialog.input.TextDialogInput;
+import io.papermc.paper.registry.data.dialog.type.DialogType;
+import io.papermc.paper.registry.data.dialog.action.DialogAction;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickCallback;
+import net.tinetwork.tradingcards.api.model.pack.PackEntry;
+import net.tinetwork.tradingcards.api.model.pack.Pack;
+import net.tinetwork.tradingcards.tradingcardsplugin.TradingCards;
+import net.tinetwork.tradingcards.tradingcardsplugin.messages.internal.InternalMessages;
+import net.tinetwork.tradingcards.tradingcardsplugin.utils.ChatUtil;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class PackEditService {
+    private static final String DISPLAY_NAME_KEY = "display_name";
+    private static final String PRICE_KEY = "price";
+    private static final String PERMISSION_KEY = "permission";
+    private static final String CURRENCY_ID_KEY = "currency_id";
+    private static final String CONTENTS_KEY = "contents";
+    private static final String TRADE_KEY = "trade";
+
+    private final TradingCards plugin;
+
+    public PackEditService(final @NotNull TradingCards plugin) {
+        this.plugin = plugin;
+    }
+
+    public void openScalarEditor(final @NotNull Player player, final @NotNull String packId) {
+        final Pack pack = plugin.getStorage().getPack(packId);
+        player.showDialog(buildEditorMenu(pack));
+    }
+
+    public boolean applyDetailsEdits(
+            final @NotNull CommandSender sender,
+            final @NotNull String packId,
+            final @NotNull String displayName,
+            final @NotNull String priceInput,
+            final @NotNull String permission,
+            final @NotNull String currencyId
+    ) {
+        final double price = parsePrice(sender, priceInput);
+        if (price <= -1.00D) {
+            ChatUtil.sendPrefixedMessage(sender, InternalMessages.EditCommand.PRICE_INCORRECT);
+            return false;
+        }
+        plugin.getStorage().editPack(packId, displayName, price, permission, currencyId);
+        plugin.getPackManager().getCache().refresh(packId);
+        ChatUtil.sendPrefixedMessage(
+                sender,
+                "&7Updated &b%s &7with &bdisplay-name&7, &bprice&7, &bpermission &7and &bcurrency-id".formatted(packId)
+        );
+        reopenEditorMenu(sender, packId);
+        return true;
+    }
+
+    public boolean applyContentsEdits(
+            final @NotNull CommandSender sender,
+            final @NotNull String packId,
+            final @NotNull String contentsInput
+    ) {
+        final Pack pack = plugin.getStorage().getPack(packId);
+        final List<PackEntry> contents = parseEntries(sender, contentsInput, "contents");
+        if (contents == null) {
+            return false;
+        }
+
+        plugin.getStorage().editPack(
+                packId,
+                pack.getDisplayName(),
+                pack.getBuyPrice(),
+                pack.getPermission(),
+                pack.getCurrencyId(),
+                contents,
+                pack.getTradeCards()
+        );
+        plugin.getPackManager().getCache().refresh(packId);
+        ChatUtil.sendPrefixedMessage(sender, "&7Updated &bcontents &7for &b%s".formatted(packId));
+        reopenEditorMenu(sender, packId);
+        return true;
+    }
+
+    public boolean applyTradeEdits(
+            final @NotNull CommandSender sender,
+            final @NotNull String packId,
+            final @NotNull String tradeInput
+    ) {
+        final Pack pack = plugin.getStorage().getPack(packId);
+        final List<PackEntry> tradeCards = parseEntries(sender, tradeInput, "trade");
+        if (tradeCards == null) {
+            return false;
+        }
+
+        plugin.getStorage().editPack(
+                packId,
+                pack.getDisplayName(),
+                pack.getBuyPrice(),
+                pack.getPermission(),
+                pack.getCurrencyId(),
+                pack.getPackEntryList(),
+                tradeCards
+        );
+        plugin.getPackManager().getCache().refresh(packId);
+        ChatUtil.sendPrefixedMessage(sender, "&7Updated &btrade &7for &b%s".formatted(packId));
+        reopenEditorMenu(sender, packId);
+        return true;
+    }
+
+    private double parsePrice(final @NotNull CommandSender sender, final @NotNull String input) {
+        try {
+            return Double.parseDouble(input);
+        } catch (NumberFormatException ignored) {
+            return -1.00D;
+        }
+    }
+
+    private @NotNull Dialog buildEditorMenu(final @NotNull Pack pack) {
+        return Dialog.create(builder -> builder.empty()
+                .base(DialogBase.builder(Component.text("Edit pack: " + pack.getId()))
+                        .body(List.of(
+                                DialogBody.plainMessage(Component.text("Display: " + pack.getDisplayName()), 320),
+                                DialogBody.plainMessage(Component.text("Price: " + pack.getBuyPrice() + " | Currency: " + orEmpty(pack.getCurrencyId())), 320),
+                                DialogBody.plainMessage(Component.text("Permission: " + orEmpty(pack.getPermission())), 320),
+                                DialogBody.plainMessage(Component.text("Contents: " + pack.getPackEntryList().size() + " entries | Trade: " + pack.getTradeCards().size() + " entries"), 320),
+                                DialogBody.plainMessage(Component.text("Choose which part of the pack to edit."), 320),
+                                DialogBody.plainMessage(Component.text("Contents and trade use one entry per line: rarity:amount:series"), 320)
+                        ))
+                        .build())
+                .type(DialogType.multiAction(List.of(
+                        ActionButton.create(
+                                Component.text("Edit Details"),
+                                Component.text("Display name, price, permission and currency"),
+                                120,
+                                DialogAction.customClick((response, audience) -> {
+                                    if (audience instanceof Player player) {
+                                        player.showDialog(buildDetailsEditor(plugin.getStorage().getPack(pack.getId())));
+                                    }
+                                }, ClickCallback.Options.builder().uses(1).build())
+                        ),
+                        ActionButton.create(
+                                Component.text("Edit Contents"),
+                                Component.text("Replace the full contents list"),
+                                120,
+                                DialogAction.customClick((response, audience) -> {
+                                    if (audience instanceof Player player) {
+                                        player.showDialog(buildContentsEditor(plugin.getStorage().getPack(pack.getId())));
+                                    }
+                                }, ClickCallback.Options.builder().uses(1).build())
+                        ),
+                        ActionButton.create(
+                                Component.text("Edit Trade"),
+                                Component.text("Replace the full trade list"),
+                                120,
+                                DialogAction.customClick((response, audience) -> {
+                                    if (audience instanceof Player player) {
+                                        player.showDialog(buildTradeEditor(plugin.getStorage().getPack(pack.getId())));
+                                    }
+                                }, ClickCallback.Options.builder().uses(1).build())
+                        )
+                ), null, 2)));
+    }
+
+    private @NotNull Dialog buildDetailsEditor(final @NotNull Pack pack) {
+        return Dialog.create(builder -> builder.empty()
+                .base(DialogBase.builder(Component.text("Edit details: " + pack.getId()))
+                        .body(List.of(
+                                DialogBody.plainMessage(Component.text("Update the scalar pack fields below."), 320)
+                        ))
+                        .inputs(List.of(
+                                DialogInput.text(DISPLAY_NAME_KEY, Component.text("Display Name"))
+                                        .initial(pack.getDisplayName())
+                                        .maxLength(128)
+                                        .width(320)
+                                        .build(),
+                                DialogInput.text(PRICE_KEY, Component.text("Price"))
+                                        .initial(String.valueOf(pack.getBuyPrice()))
+                                        .maxLength(32)
+                                        .width(320)
+                                        .build(),
+                                DialogInput.text(PERMISSION_KEY, Component.text("Permission"))
+                                        .initial(orEmpty(pack.getPermission()))
+                                        .maxLength(128)
+                                        .width(320)
+                                        .build(),
+                                DialogInput.text(CURRENCY_ID_KEY, Component.text("Currency Id"))
+                                        .initial(orEmpty(pack.getCurrencyId()))
+                                        .maxLength(128)
+                                        .width(320)
+                                        .build()
+                        ))
+                        .canCloseWithEscape(true)
+                        .build())
+                .type(DialogType.confirmation(
+                        ActionButton.create(
+                                Component.text("Save"),
+                                Component.text("Apply these detail edits"),
+                                120,
+                                DialogAction.customClick((response, audience) -> {
+                                    if (audience instanceof Player player) {
+                                        applyDetailsEdits(
+                                                player,
+                                                pack.getId(),
+                                                textValue(response.getText(DISPLAY_NAME_KEY)),
+                                                textValue(response.getText(PRICE_KEY)),
+                                                textValue(response.getText(PERMISSION_KEY)),
+                                                textValue(response.getText(CURRENCY_ID_KEY))
+                                        );
+                                    }
+                                }, ClickCallback.Options.builder().uses(1).build())
+                        ),
+                        ActionButton.create(
+                                Component.text("Cancel"),
+                                Component.text("Discard these changes"),
+                                120,
+                                null
+                        )
+                )));
+    }
+
+    private @NotNull Dialog buildContentsEditor(final @NotNull Pack pack) {
+        return buildListEditor(
+                pack,
+                "Edit contents: ",
+                CONTENTS_KEY,
+                "Contents",
+                "Replace the full contents list. One entry per line.",
+                "Example: common:9:default",
+                joinEntries(pack.getPackEntryList()),
+                "Save Contents",
+                "Apply these contents edits",
+                (player, value) -> applyContentsEdits(player, pack.getId(), value)
+        );
+    }
+
+    private @NotNull Dialog buildTradeEditor(final @NotNull Pack pack) {
+        return buildListEditor(
+                pack,
+                "Edit trade: ",
+                TRADE_KEY,
+                "Trade",
+                "Replace the full trade list. Leave blank for no trade entries.",
+                "Example: rare:2:default",
+                joinEntries(pack.getTradeCards()),
+                "Save Trade",
+                "Apply these trade edits",
+                (player, value) -> applyTradeEdits(player, pack.getId(), value)
+        );
+    }
+
+    private @NotNull Dialog buildListEditor(
+            final @NotNull Pack pack,
+            final @NotNull String titlePrefix,
+            final @NotNull String inputKey,
+            final @NotNull String label,
+            final @NotNull String description,
+            final @NotNull String example,
+            final @NotNull String initialValue,
+            final @NotNull String submitText,
+            final @NotNull String submitHover,
+            final @NotNull PlayerInputHandler inputHandler
+    ) {
+        return Dialog.create(builder -> builder.empty()
+                .base(DialogBase.builder(Component.text(titlePrefix + pack.getId()))
+                        .body(List.of(
+                                DialogBody.plainMessage(Component.text(description), 340),
+                                DialogBody.plainMessage(Component.text(example), 340)
+                        ))
+                        .inputs(List.of(
+                                DialogInput.text(inputKey, Component.text(label))
+                                        .initial(initialValue)
+                                        .maxLength(4096)
+                                        .width(340)
+                                        .multiline(TextDialogInput.MultilineOptions.create(20, 160))
+                                        .build()
+                        ))
+                        .canCloseWithEscape(true)
+                        .build())
+                .type(DialogType.confirmation(
+                        ActionButton.create(
+                                Component.text(submitText),
+                                Component.text(submitHover),
+                                120,
+                                DialogAction.customClick((response, audience) -> {
+                                    if (audience instanceof Player player) {
+                                        inputHandler.apply(player, textValue(response.getText(inputKey)));
+                                    }
+                                }, ClickCallback.Options.builder().uses(1).build())
+                        ),
+                        ActionButton.create(
+                                Component.text("Cancel"),
+                                Component.text("Discard these changes"),
+                                120,
+                                null
+                        )
+                )));
+    }
+
+    private List<PackEntry> parseEntries(final @NotNull CommandSender sender, final @NotNull String input, final @NotNull String fieldName) {
+        final List<PackEntry> entries = new ArrayList<>();
+        if (input.isBlank()) {
+            return entries;
+        }
+
+        final String[] lines = input.split("\\R");
+        for (int i = 0; i < lines.length; i++) {
+            final String line = lines[i].trim();
+            if (line.isEmpty()) {
+                continue;
+            }
+
+            try {
+                final PackEntry entry = PackEntry.fromString(line);
+                if (!plugin.getRarityManager().containsRarity(entry.getRarityId())) {
+                    ChatUtil.sendPrefixedMessage(sender, InternalMessages.NO_RARITY.formatted(entry.getRarityId()));
+                    return null;
+                }
+                final String seriesId = entry.seriesId();
+                if (seriesId != null && !plugin.getSeriesManager().containsSeries(seriesId)) {
+                    ChatUtil.sendPrefixedMessage(sender, InternalMessages.NO_SERIES.formatted(seriesId));
+                    return null;
+                }
+                entries.add(entry);
+            } catch (RuntimeException ignored) {
+                ChatUtil.sendPrefixedMessage(sender, "&4Invalid %s entry on line %s: &c%s".formatted(fieldName, i + 1, line));
+                ChatUtil.sendPrefixedMessage(sender, "&7Expected format: &brarity:amount:series");
+                return null;
+            }
+        }
+
+        return entries;
+    }
+
+    private @NotNull String joinEntries(final @NotNull List<PackEntry> entries) {
+        return entries.stream().map(PackEntry::toString).reduce((left, right) -> left + "\n" + right).orElse("");
+    }
+
+    private @NotNull String textValue(final String input) {
+        return input == null ? "" : input.trim();
+    }
+
+    private @NotNull String orEmpty(final String input) {
+        return input == null ? "" : input;
+    }
+
+    private void reopenEditorMenu(final @NotNull CommandSender sender, final @NotNull String packId) {
+        if (sender instanceof Player player) {
+            player.showDialog(buildEditorMenu(plugin.getStorage().getPack(packId)));
+        }
+    }
+
+    @FunctionalInterface
+    private interface PlayerInputHandler {
+        boolean apply(Player player, String value);
+    }
+}

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/edit/PackEditService.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/edit/PackEditService.java
@@ -166,6 +166,20 @@ public final class PackEditService {
                                         player.showDialog(buildTradeEditor(plugin.getStorage().getPack(pack.getId())));
                                     }
                                 }, ClickCallback.Options.builder().uses(1).build())
+                        ),
+                        ActionButton.create(
+                                Component.text("Preview Item"),
+                                Component.text("Preview the current pack item"),
+                                120,
+                                DialogAction.customClick((response, audience) -> {
+                                    if (audience instanceof Player player) {
+                                        player.showDialog(buildPreviewDialog(
+                                                "Pack preview: " + pack.getId(),
+                                                plugin.getStorage().getPack(pack.getId()),
+                                                previewPlayer -> previewPlayer.showDialog(buildEditorMenu(plugin.getStorage().getPack(pack.getId())))
+                                        ));
+                                    }
+                                }, ClickCallback.Options.builder().uses(1).build())
                         )
                 ), null, 2)));
     }
@@ -200,7 +214,7 @@ public final class PackEditService {
                         ))
                         .canCloseWithEscape(true)
                         .build())
-                .type(DialogType.confirmation(
+                .type(DialogType.multiAction(List.of(
                         ActionButton.create(
                                 Component.text("Save"),
                                 Component.text("Apply these detail edits"),
@@ -219,12 +233,36 @@ public final class PackEditService {
                                 }, ClickCallback.Options.builder().uses(1).build())
                         ),
                         ActionButton.create(
+                                Component.text("Preview"),
+                                Component.text("Preview the pack item with these values"),
+                                120,
+                                DialogAction.customClick((response, audience) -> {
+                                    if (audience instanceof Player player) {
+                                        final Pack previewPack = buildDetailsPreviewPack(
+                                                player,
+                                                pack,
+                                                textValue(response.getText(DISPLAY_NAME_KEY)),
+                                                textValue(response.getText(PRICE_KEY)),
+                                                textValue(response.getText(PERMISSION_KEY)),
+                                                textValue(response.getText(CURRENCY_ID_KEY))
+                                        );
+                                        if (previewPack != null) {
+                                            player.showDialog(buildPreviewDialog(
+                                                    "Pack preview: " + pack.getId(),
+                                                    previewPack,
+                                                    previewPlayer -> previewPlayer.showDialog(buildDetailsEditor(plugin.getStorage().getPack(pack.getId())))
+                                            ));
+                                        }
+                                    }
+                                }, ClickCallback.Options.builder().uses(1).build())
+                        ),
+                        ActionButton.create(
                                 Component.text("Cancel"),
                                 Component.text("Discard these changes"),
                                 120,
                                 null
                         )
-                )));
+                ), null, 2)));
     }
 
     private @NotNull Dialog buildContentsEditor(final @NotNull Pack pack) {
@@ -238,6 +276,9 @@ public final class PackEditService {
                 joinEntries(pack.getPackEntryList()),
                 "Save Contents",
                 "Apply these contents edits",
+                "Preview",
+                "Preview the pack item with these values",
+                (sender, value) -> buildContentsPreviewPack(sender, pack, value),
                 (player, value) -> applyContentsEdits(player, pack.getId(), value)
         );
     }
@@ -253,6 +294,9 @@ public final class PackEditService {
                 joinEntries(pack.getTradeCards()),
                 "Save Trade",
                 "Apply these trade edits",
+                "Preview",
+                "Preview the pack item with these values",
+                (sender, value) -> buildTradePreviewPack(sender, pack, value),
                 (player, value) -> applyTradeEdits(player, pack.getId(), value)
         );
     }
@@ -267,6 +311,9 @@ public final class PackEditService {
             final @NotNull String initialValue,
             final @NotNull String submitText,
             final @NotNull String submitHover,
+            final @NotNull String previewText,
+            final @NotNull String previewHover,
+            final @NotNull PreviewPackBuilder previewBuilder,
             final @NotNull PlayerInputHandler inputHandler
     ) {
         return Dialog.create(builder -> builder.empty()
@@ -285,7 +332,7 @@ public final class PackEditService {
                         ))
                         .canCloseWithEscape(true)
                         .build())
-                .type(DialogType.confirmation(
+                .type(DialogType.multiAction(List.of(
                         ActionButton.create(
                                 Component.text(submitText),
                                 Component.text(submitHover),
@@ -297,12 +344,120 @@ public final class PackEditService {
                                 }, ClickCallback.Options.builder().uses(1).build())
                         ),
                         ActionButton.create(
+                                Component.text(previewText),
+                                Component.text(previewHover),
+                                120,
+                                DialogAction.customClick((response, audience) -> {
+                                    if (audience instanceof Player player) {
+                                        final String inputValue = textValue(response.getText(inputKey));
+                                        final Pack previewPack = previewBuilder.build(player, inputValue);
+                                        if (previewPack != null) {
+                                            player.showDialog(buildPreviewDialog(
+                                                    "Pack preview: " + pack.getId(),
+                                                    previewPack,
+                                                    previewPlayer -> previewPlayer.showDialog(
+                                                            CONTENTS_KEY.equals(inputKey)
+                                                                    ? buildContentsEditor(plugin.getStorage().getPack(pack.getId()))
+                                                                    : buildTradeEditor(plugin.getStorage().getPack(pack.getId()))
+                                                    )
+                                            ));
+                                        }
+                                    }
+                                }, ClickCallback.Options.builder().uses(1).build())
+                        ),
+                        ActionButton.create(
                                 Component.text("Cancel"),
                                 Component.text("Discard these changes"),
                                 120,
                                 null
                         )
-                )));
+                ), null, 2)));
+    }
+
+    private Pack buildDetailsPreviewPack(
+            final @NotNull CommandSender sender,
+            final @NotNull Pack pack,
+            final @NotNull String displayName,
+            final @NotNull String priceInput,
+            final @NotNull String permission,
+            final @NotNull String currencyId
+    ) {
+        final double price = parsePrice(sender, priceInput);
+        if (price <= -1.00D) {
+            ChatUtil.sendPrefixedMessage(sender, InternalMessages.EditCommand.PRICE_INCORRECT);
+            return null;
+        }
+
+        return new Pack(
+                pack.getId(),
+                pack.getPackEntryList(),
+                displayName,
+                price,
+                currencyId,
+                permission,
+                pack.getTradeCards()
+        );
+    }
+
+    private Pack buildContentsPreviewPack(final @NotNull CommandSender sender, final @NotNull Pack pack, final @NotNull String contentsInput) {
+        final List<PackEntry> contents = parseEntries(sender, contentsInput, "contents");
+        if (contents == null) {
+            return null;
+        }
+        return new Pack(
+                pack.getId(),
+                contents,
+                pack.getDisplayName(),
+                pack.getBuyPrice(),
+                pack.getCurrencyId(),
+                pack.getPermission(),
+                pack.getTradeCards()
+        );
+    }
+
+    private Pack buildTradePreviewPack(final @NotNull CommandSender sender, final @NotNull Pack pack, final @NotNull String tradeInput) {
+        final List<PackEntry> tradeCards = parseEntries(sender, tradeInput, "trade");
+        if (tradeCards == null) {
+            return null;
+        }
+        return new Pack(
+                pack.getId(),
+                pack.getPackEntryList(),
+                pack.getDisplayName(),
+                pack.getBuyPrice(),
+                pack.getCurrencyId(),
+                pack.getPermission(),
+                tradeCards
+        );
+    }
+
+    private @NotNull Dialog buildPreviewDialog(
+            final @NotNull String title,
+            final @NotNull Pack pack,
+            final @NotNull PreviewReturn previewReturn
+    ) {
+        return Dialog.create(builder -> builder.empty()
+                .base(DialogBase.builder(Component.text(title))
+                        .body(List.of(
+                                DialogBody.plainMessage(Component.text("Previewing the resulting pack item."), 340),
+                                DialogBody.plainMessage(Component.text("Display: " + pack.getDisplayName()), 340),
+                                DialogBody.plainMessage(Component.text("Price: " + pack.getBuyPrice() + " | Currency: " + orEmpty(pack.getCurrencyId())), 340),
+                                DialogBody.plainMessage(Component.text("Contents: " + pack.getPackEntryList().size() + " entries | Trade: " + pack.getTradeCards().size() + " entries"), 340),
+                                DialogBody.item(plugin.getPackManager().generatePack(pack)).build()
+                        ))
+                        .build())
+                .type(DialogType.multiAction(List.of(
+                        ActionButton.create(
+                                Component.text("Back"),
+                                Component.text("Return to the editor"),
+                                120,
+                                DialogAction.customClick((response, audience) -> {
+                                    if (audience instanceof Player player) {
+                                        previewReturn.show(player);
+                                    }
+                                }, ClickCallback.Options.builder().uses(1).build())
+                        )
+                ), null, 1)));
     }
 
     private List<PackEntry> parseEntries(final @NotNull CommandSender sender, final @NotNull String input, final @NotNull String fieldName) {
@@ -361,5 +516,15 @@ public final class PackEditService {
     @FunctionalInterface
     private interface PlayerInputHandler {
         boolean apply(Player player, String value);
+    }
+
+    @FunctionalInterface
+    private interface PreviewPackBuilder {
+        Pack build(CommandSender sender, String value);
+    }
+
+    @FunctionalInterface
+    private interface PreviewReturn {
+        void show(Player player);
     }
 }

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/edit/PackEditService.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/edit/PackEditService.java
@@ -128,7 +128,7 @@ public final class PackEditService {
         return Dialog.create(builder -> builder.empty()
                 .base(DialogBase.builder(Component.text("Edit pack: " + pack.getId()))
                         .body(List.of(
-                                DialogBody.plainMessage(Component.text("Display: " + pack.getDisplayName()), 320),
+                                DialogBody.plainMessage(Component.text("Display: ").append(ChatUtil.component(pack.getDisplayName())), 320),
                                 DialogBody.plainMessage(Component.text("Price: " + pack.getBuyPrice() + " | Currency: " + orEmpty(pack.getCurrencyId())), 320),
                                 DialogBody.plainMessage(Component.text("Permission: " + orEmpty(pack.getPermission())), 320),
                                 DialogBody.plainMessage(Component.text("Contents: " + pack.getPackEntryList().size() + " entries | Trade: " + pack.getTradeCards().size() + " entries"), 320),
@@ -440,7 +440,7 @@ public final class PackEditService {
                 .base(DialogBase.builder(Component.text(title))
                         .body(List.of(
                                 DialogBody.plainMessage(Component.text("Previewing the resulting pack item."), 340),
-                                DialogBody.plainMessage(Component.text("Display: " + pack.getDisplayName()), 340),
+                                DialogBody.plainMessage(Component.text("Display: ").append(ChatUtil.component(pack.getDisplayName())), 340),
                                 DialogBody.plainMessage(Component.text("Price: " + pack.getBuyPrice() + " | Currency: " + orEmpty(pack.getCurrencyId())), 340),
                                 DialogBody.plainMessage(Component.text("Contents: " + pack.getPackEntryList().size() + " entries | Trade: " + pack.getTradeCards().size() + " entries"), 340),
                                 DialogBody.item(plugin.getPackManager().generatePack(pack)).build()

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/edit/RarityEditService.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/edit/RarityEditService.java
@@ -1,0 +1,232 @@
+package net.tinetwork.tradingcards.tradingcardsplugin.commands.edit;
+
+import io.papermc.paper.dialog.Dialog;
+import io.papermc.paper.registry.data.dialog.ActionButton;
+import io.papermc.paper.registry.data.dialog.DialogBase;
+import io.papermc.paper.registry.data.dialog.action.DialogAction;
+import io.papermc.paper.registry.data.dialog.body.DialogBody;
+import io.papermc.paper.registry.data.dialog.input.DialogInput;
+import io.papermc.paper.registry.data.dialog.input.TextDialogInput;
+import io.papermc.paper.registry.data.dialog.type.DialogType;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickCallback;
+import net.tinetwork.tradingcards.api.model.Rarity;
+import net.tinetwork.tradingcards.tradingcardsplugin.TradingCards;
+import net.tinetwork.tradingcards.tradingcardsplugin.messages.internal.InternalMessages;
+import net.tinetwork.tradingcards.tradingcardsplugin.utils.ChatUtil;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class RarityEditService {
+    private static final String DISPLAY_NAME_KEY = "display_name";
+    private static final String DEFAULT_COLOR_KEY = "default_color";
+    private static final String BUY_PRICE_KEY = "buy_price";
+    private static final String SELL_PRICE_KEY = "sell_price";
+    private static final String CURRENCY_ID_KEY = "currency_id";
+    private static final String REWARDS_KEY = "rewards";
+
+    private final TradingCards plugin;
+
+    public RarityEditService(final @NotNull TradingCards plugin) {
+        this.plugin = plugin;
+    }
+
+    public void openEditor(final @NotNull Player player, final @NotNull String rarityId) {
+        player.showDialog(buildEditorMenu(plugin.getRarityManager().getRarity(rarityId)));
+    }
+
+    public boolean applyDetailsEdits(
+            final @NotNull CommandSender sender,
+            final @NotNull String rarityId,
+            final @NotNull String displayName,
+            final @NotNull String defaultColor,
+            final @NotNull String buyPriceInput,
+            final @NotNull String sellPriceInput,
+            final @NotNull String currencyId
+    ) {
+        final double buyPrice = parsePrice(buyPriceInput);
+        final double sellPrice = parsePrice(sellPriceInput);
+        if (buyPrice <= -1.00D || sellPrice <= -1.00D) {
+            ChatUtil.sendPrefixedMessage(sender, InternalMessages.EditCommand.PRICE_INCORRECT);
+            return false;
+        }
+
+        final Rarity rarity = plugin.getRarityManager().getRarity(rarityId);
+        plugin.getStorage().editRarity(
+                rarityId,
+                displayName,
+                defaultColor,
+                buyPrice,
+                sellPrice,
+                currencyId,
+                rarity.getRewards()
+        );
+        plugin.getRarityManager().getRarityCache().refresh(rarityId);
+        ChatUtil.sendPrefixedMessage(sender, "&7Updated &brarity details &7for &b%s".formatted(rarityId));
+        reopenEditor(sender, rarityId);
+        return true;
+    }
+
+    public boolean applyRewardsEdits(final @NotNull CommandSender sender, final @NotNull String rarityId, final @NotNull String rewardsInput) {
+        final Rarity rarity = plugin.getRarityManager().getRarity(rarityId);
+        plugin.getStorage().editRarity(
+                rarityId,
+                rarity.getDisplayName(),
+                rarity.getDefaultColor(),
+                rarity.getBuyPrice(),
+                rarity.getSellPrice(),
+                rarity.getCurrencyId(),
+                parseLines(rewardsInput)
+        );
+        plugin.getRarityManager().getRarityCache().refresh(rarityId);
+        ChatUtil.sendPrefixedMessage(sender, "&7Updated &brewards &7for &b%s".formatted(rarityId));
+        reopenEditor(sender, rarityId);
+        return true;
+    }
+
+    private @NotNull Dialog buildEditorMenu(final @NotNull Rarity rarity) {
+        return Dialog.create(builder -> builder.empty()
+                .base(DialogBase.builder(Component.text("Edit rarity: " + rarity.getId()))
+                        .body(List.of(
+                                DialogBody.plainMessage(Component.text("Display: " + rarity.getDisplayName()), 320),
+                                DialogBody.plainMessage(Component.text("Buy: " + rarity.getBuyPrice() + " | Sell: " + rarity.getSellPrice()), 320),
+                                DialogBody.plainMessage(Component.text("Color: " + orEmpty(rarity.getDefaultColor()) + " | Currency: " + orEmpty(rarity.getCurrencyId())), 320),
+                                DialogBody.plainMessage(Component.text("Rewards: " + rarity.getRewards().size() + " entries"), 320)
+                        ))
+                        .build())
+                .type(DialogType.multiAction(List.of(
+                        ActionButton.create(
+                                Component.text("Edit Details"),
+                                Component.text("Display name, color, prices, currency"),
+                                120,
+                                DialogAction.customClick((response, audience) -> {
+                                    if (audience instanceof Player player) {
+                                        player.showDialog(buildDetailsEditor(plugin.getRarityManager().getRarity(rarity.getId())));
+                                    }
+                                }, ClickCallback.Options.builder().uses(1).build())
+                        ),
+                        ActionButton.create(
+                                Component.text("Edit Rewards"),
+                                Component.text("Replace the full rewards list"),
+                                120,
+                                DialogAction.customClick((response, audience) -> {
+                                    if (audience instanceof Player player) {
+                                        player.showDialog(buildRewardsEditor(plugin.getRarityManager().getRarity(rarity.getId())));
+                                    }
+                                }, ClickCallback.Options.builder().uses(1).build())
+                        )
+                ), null, 2)));
+    }
+
+    private @NotNull Dialog buildDetailsEditor(final @NotNull Rarity rarity) {
+        return Dialog.create(builder -> builder.empty()
+                .base(DialogBase.builder(Component.text("Edit rarity details: " + rarity.getId()))
+                        .body(List.of(DialogBody.plainMessage(Component.text("Update the scalar rarity fields below."), 320)))
+                        .inputs(List.of(
+                                DialogInput.text(DISPLAY_NAME_KEY, Component.text("Display Name")).initial(rarity.getDisplayName()).maxLength(128).width(320).build(),
+                                DialogInput.text(DEFAULT_COLOR_KEY, Component.text("Default Color")).initial(orEmpty(rarity.getDefaultColor())).maxLength(64).width(320).build(),
+                                DialogInput.text(BUY_PRICE_KEY, Component.text("Buy Price")).initial(String.valueOf(rarity.getBuyPrice())).maxLength(32).width(320).build(),
+                                DialogInput.text(SELL_PRICE_KEY, Component.text("Sell Price")).initial(String.valueOf(rarity.getSellPrice())).maxLength(32).width(320).build(),
+                                DialogInput.text(CURRENCY_ID_KEY, Component.text("Currency Id")).initial(orEmpty(rarity.getCurrencyId())).maxLength(128).width(320).build()
+                        ))
+                        .canCloseWithEscape(true)
+                        .build())
+                .type(DialogType.confirmation(
+                        ActionButton.create(
+                                Component.text("Save"),
+                                Component.text("Apply these rarity detail edits"),
+                                120,
+                                DialogAction.customClick((response, audience) -> {
+                                    if (audience instanceof Player player) {
+                                        applyDetailsEdits(
+                                                player,
+                                                rarity.getId(),
+                                                textValue(response.getText(DISPLAY_NAME_KEY)),
+                                                textValue(response.getText(DEFAULT_COLOR_KEY)),
+                                                textValue(response.getText(BUY_PRICE_KEY)),
+                                                textValue(response.getText(SELL_PRICE_KEY)),
+                                                textValue(response.getText(CURRENCY_ID_KEY))
+                                        );
+                                    }
+                                }, ClickCallback.Options.builder().uses(1).build())
+                        ),
+                        ActionButton.create(Component.text("Cancel"), Component.text("Discard these changes"), 120, null)
+                )));
+    }
+
+    private @NotNull Dialog buildRewardsEditor(final @NotNull Rarity rarity) {
+        return Dialog.create(builder -> builder.empty()
+                .base(DialogBase.builder(Component.text("Edit rarity rewards: " + rarity.getId()))
+                        .body(List.of(
+                                DialogBody.plainMessage(Component.text("Replace the full rewards list. One command per line."), 340),
+                                DialogBody.plainMessage(Component.text("Leave blank for no rewards."), 340)
+                        ))
+                        .inputs(List.of(
+                                DialogInput.text(REWARDS_KEY, Component.text("Rewards"))
+                                        .initial(joinLines(rarity.getRewards()))
+                                        .maxLength(4096)
+                                        .width(340)
+                                        .multiline(TextDialogInput.MultilineOptions.create(20, 160))
+                                        .build()
+                        ))
+                        .canCloseWithEscape(true)
+                        .build())
+                .type(DialogType.confirmation(
+                        ActionButton.create(
+                                Component.text("Save Rewards"),
+                                Component.text("Apply these reward edits"),
+                                120,
+                                DialogAction.customClick((response, audience) -> {
+                                    if (audience instanceof Player player) {
+                                        applyRewardsEdits(player, rarity.getId(), textValue(response.getText(REWARDS_KEY)));
+                                    }
+                                }, ClickCallback.Options.builder().uses(1).build())
+                        ),
+                        ActionButton.create(Component.text("Cancel"), Component.text("Discard these changes"), 120, null)
+                )));
+    }
+
+    private void reopenEditor(final @NotNull CommandSender sender, final @NotNull String rarityId) {
+        if (sender instanceof Player player) {
+            player.showDialog(buildEditorMenu(plugin.getRarityManager().getRarity(rarityId)));
+        }
+    }
+
+    private double parsePrice(final @NotNull String input) {
+        try {
+            return Double.parseDouble(input);
+        } catch (NumberFormatException ignored) {
+            return -1.00D;
+        }
+    }
+
+    private @NotNull List<String> parseLines(final @NotNull String input) {
+        final List<String> lines = new ArrayList<>();
+        if (input.isBlank()) {
+            return lines;
+        }
+        for (String line : input.split("\\R")) {
+            final String trimmed = line.trim();
+            if (!trimmed.isEmpty()) {
+                lines.add(trimmed);
+            }
+        }
+        return lines;
+    }
+
+    private @NotNull String joinLines(final @NotNull List<String> values) {
+        return values.stream().reduce((left, right) -> left + "\n" + right).orElse("");
+    }
+
+    private @NotNull String textValue(final String input) {
+        return input == null ? "" : input.trim();
+    }
+
+    private @NotNull String orEmpty(final String input) {
+        return input == null ? "" : input;
+    }
+}

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/edit/RarityEditService.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/edit/RarityEditService.java
@@ -92,7 +92,7 @@ public final class RarityEditService {
         return Dialog.create(builder -> builder.empty()
                 .base(DialogBase.builder(Component.text("Edit rarity: " + rarity.getId()))
                         .body(List.of(
-                                DialogBody.plainMessage(Component.text("Display: " + rarity.getDisplayName()), 320),
+                                DialogBody.plainMessage(Component.text("Display: ").append(ChatUtil.component(rarity.getDisplayName())), 320),
                                 DialogBody.plainMessage(Component.text("Buy: " + rarity.getBuyPrice() + " | Sell: " + rarity.getSellPrice()), 320),
                                 DialogBody.plainMessage(Component.text("Color: " + orEmpty(rarity.getDefaultColor()) + " | Currency: " + orEmpty(rarity.getCurrencyId())), 320),
                                 DialogBody.plainMessage(Component.text("Rewards: " + rarity.getRewards().size() + " entries"), 320)

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/edit/SeriesEditService.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/edit/SeriesEditService.java
@@ -75,7 +75,7 @@ public final class SeriesEditService {
         return Dialog.create(builder -> builder.empty()
                 .base(DialogBase.builder(Component.text("Edit series: " + series.getId()))
                         .body(List.of(
-                                DialogBody.plainMessage(Component.text("Display: " + series.getDisplayName() + " | Mode: " + series.getMode()), 340),
+                                DialogBody.plainMessage(Component.text("Display: ").append(ChatUtil.component(series.getDisplayName())).append(Component.text(" | Mode: " + series.getMode())), 340),
                                 DialogBody.plainMessage(Component.text("Update display name, mode, and the color tokens below."), 340)
                         ))
                         .inputs(List.of(

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/edit/SeriesEditService.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/edit/SeriesEditService.java
@@ -1,0 +1,126 @@
+package net.tinetwork.tradingcards.tradingcardsplugin.commands.edit;
+
+import io.papermc.paper.dialog.Dialog;
+import io.papermc.paper.registry.data.dialog.ActionButton;
+import io.papermc.paper.registry.data.dialog.DialogBase;
+import io.papermc.paper.registry.data.dialog.action.DialogAction;
+import io.papermc.paper.registry.data.dialog.body.DialogBody;
+import io.papermc.paper.registry.data.dialog.input.DialogInput;
+import io.papermc.paper.registry.data.dialog.type.DialogType;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickCallback;
+import net.tinetwork.tradingcards.api.config.ColorSeries;
+import net.tinetwork.tradingcards.api.model.Series;
+import net.tinetwork.tradingcards.api.model.schedule.Mode;
+import net.tinetwork.tradingcards.tradingcardsplugin.TradingCards;
+import net.tinetwork.tradingcards.tradingcardsplugin.messages.internal.InternalMessages;
+import net.tinetwork.tradingcards.tradingcardsplugin.utils.ChatUtil;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.List;
+
+public final class SeriesEditService {
+    private static final String DISPLAY_NAME_KEY = "display_name";
+    private static final String MODE_KEY = "mode";
+    private static final String SERIES_COLOR_KEY = "series_color";
+    private static final String TYPE_COLOR_KEY = "type_color";
+    private static final String INFO_COLOR_KEY = "info_color";
+    private static final String ABOUT_COLOR_KEY = "about_color";
+    private static final String RARITY_COLOR_KEY = "rarity_color";
+
+    private final TradingCards plugin;
+
+    public SeriesEditService(final @NotNull TradingCards plugin) {
+        this.plugin = plugin;
+    }
+
+    public void openEditor(final @NotNull Player player, final @NotNull String seriesId) {
+        player.showDialog(buildEditor(plugin.getSeriesManager().getSeries(seriesId)));
+    }
+
+    public boolean applyEdits(
+            final @NotNull CommandSender sender,
+            final @NotNull String seriesId,
+            final @NotNull String displayName,
+            final @NotNull String modeInput,
+            final @NotNull String seriesColor,
+            final @NotNull String typeColor,
+            final @NotNull String infoColor,
+            final @NotNull String aboutColor,
+            final @NotNull String rarityColor
+    ) {
+        final Mode mode = Mode.getMode(modeInput);
+        if (mode == null) {
+            ChatUtil.sendPrefixedMessage(sender, InternalMessages.EditCommand.MODE_INCORRECT.formatted(Arrays.toString(Mode.values())));
+            return false;
+        }
+
+        plugin.getStorage().editSeries(
+                seriesId,
+                displayName,
+                mode,
+                new ColorSeries(seriesColor, typeColor, infoColor, aboutColor, rarityColor)
+        );
+        plugin.getSeriesManager().getCache().refresh(seriesId);
+        ChatUtil.sendPrefixedMessage(sender, "&7Updated &bseries &7for &b%s".formatted(seriesId));
+        reopenEditor(sender, seriesId);
+        return true;
+    }
+
+    private @NotNull Dialog buildEditor(final @NotNull Series series) {
+        final ColorSeries colors = series.getColorSeries();
+        return Dialog.create(builder -> builder.empty()
+                .base(DialogBase.builder(Component.text("Edit series: " + series.getId()))
+                        .body(List.of(
+                                DialogBody.plainMessage(Component.text("Display: " + series.getDisplayName() + " | Mode: " + series.getMode()), 340),
+                                DialogBody.plainMessage(Component.text("Update display name, mode, and the color tokens below."), 340)
+                        ))
+                        .inputs(List.of(
+                                DialogInput.text(DISPLAY_NAME_KEY, Component.text("Display Name")).initial(series.getDisplayName()).maxLength(128).width(320).build(),
+                                DialogInput.text(MODE_KEY, Component.text("Mode")).initial(series.getMode().name()).maxLength(32).width(320).build(),
+                                DialogInput.text(SERIES_COLOR_KEY, Component.text("Series Color")).initial(colors.getSeries()).maxLength(32).width(320).build(),
+                                DialogInput.text(TYPE_COLOR_KEY, Component.text("Type Color")).initial(colors.getType()).maxLength(32).width(320).build(),
+                                DialogInput.text(INFO_COLOR_KEY, Component.text("Info Color")).initial(colors.getInfo()).maxLength(32).width(320).build(),
+                                DialogInput.text(ABOUT_COLOR_KEY, Component.text("About Color")).initial(colors.getAbout()).maxLength(32).width(320).build(),
+                                DialogInput.text(RARITY_COLOR_KEY, Component.text("Rarity Color")).initial(colors.getRarity()).maxLength(32).width(320).build()
+                        ))
+                        .canCloseWithEscape(true)
+                        .build())
+                .type(DialogType.confirmation(
+                        ActionButton.create(
+                                Component.text("Save"),
+                                Component.text("Apply these series edits"),
+                                120,
+                                DialogAction.customClick((response, audience) -> {
+                                    if (audience instanceof Player player) {
+                                        applyEdits(
+                                                player,
+                                                series.getId(),
+                                                textValue(response.getText(DISPLAY_NAME_KEY)),
+                                                textValue(response.getText(MODE_KEY)),
+                                                textValue(response.getText(SERIES_COLOR_KEY)),
+                                                textValue(response.getText(TYPE_COLOR_KEY)),
+                                                textValue(response.getText(INFO_COLOR_KEY)),
+                                                textValue(response.getText(ABOUT_COLOR_KEY)),
+                                                textValue(response.getText(RARITY_COLOR_KEY))
+                                        );
+                                    }
+                                }, ClickCallback.Options.builder().uses(1).build())
+                        ),
+                        ActionButton.create(Component.text("Cancel"), Component.text("Discard these changes"), 120, null)
+                )));
+    }
+
+    private void reopenEditor(final @NotNull CommandSender sender, final @NotNull String seriesId) {
+        if (sender instanceof Player player) {
+            player.showDialog(buildEditor(plugin.getSeriesManager().getSeries(seriesId)));
+        }
+    }
+
+    private @NotNull String textValue(final String input) {
+        return input == null ? "" : input.trim();
+    }
+}

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/edit/TypeEditService.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/edit/TypeEditService.java
@@ -51,7 +51,7 @@ public final class TypeEditService {
         return Dialog.create(builder -> builder.empty()
                 .base(DialogBase.builder(Component.text("Edit type: " + dropType.getId()))
                         .body(List.of(
-                                DialogBody.plainMessage(Component.text("Display: " + dropType.getDisplayName() + " | Type: " + dropType.getType()), 320),
+                                DialogBody.plainMessage(Component.text("Display: ").append(ChatUtil.component(dropType.getDisplayName())).append(Component.text(" | Type: " + dropType.getType())), 320),
                                 DialogBody.plainMessage(Component.text("Allowed types: " + plugin.getDropTypeManager().getDefaultTypes().stream().map(DropType::getId).toList()), 320)
                         ))
                         .inputs(List.of(

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/edit/TypeEditService.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/edit/TypeEditService.java
@@ -1,0 +1,87 @@
+package net.tinetwork.tradingcards.tradingcardsplugin.commands.edit;
+
+import io.papermc.paper.dialog.Dialog;
+import io.papermc.paper.registry.data.dialog.ActionButton;
+import io.papermc.paper.registry.data.dialog.DialogBase;
+import io.papermc.paper.registry.data.dialog.action.DialogAction;
+import io.papermc.paper.registry.data.dialog.body.DialogBody;
+import io.papermc.paper.registry.data.dialog.input.DialogInput;
+import io.papermc.paper.registry.data.dialog.type.DialogType;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickCallback;
+import net.tinetwork.tradingcards.api.model.DropType;
+import net.tinetwork.tradingcards.tradingcardsplugin.TradingCards;
+import net.tinetwork.tradingcards.tradingcardsplugin.messages.internal.InternalMessages;
+import net.tinetwork.tradingcards.tradingcardsplugin.utils.ChatUtil;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public final class TypeEditService {
+    private static final String DISPLAY_NAME_KEY = "display_name";
+    private static final String TYPE_KEY = "type";
+
+    private final TradingCards plugin;
+
+    public TypeEditService(final @NotNull TradingCards plugin) {
+        this.plugin = plugin;
+    }
+
+    public void openEditor(final @NotNull Player player, final @NotNull String typeId) {
+        player.showDialog(buildEditor(plugin.getDropTypeManager().getType(typeId)));
+    }
+
+    public boolean applyEdits(final @NotNull CommandSender sender, final @NotNull String typeId, final @NotNull String displayName, final @NotNull String type) {
+        final List<String> defaultTypes = plugin.getDropTypeManager().getDefaultTypes().stream().map(DropType::getId).toList();
+        if (!defaultTypes.contains(type)) {
+            ChatUtil.sendPrefixedMessage(sender, InternalMessages.TYPE_MUST_BE.formatted(defaultTypes));
+            return false;
+        }
+
+        plugin.getStorage().editCustomType(typeId, displayName, type);
+        plugin.getDropTypeManager().getCache().refresh(typeId);
+        ChatUtil.sendPrefixedMessage(sender, "&7Updated &btype &7for &b%s".formatted(typeId));
+        reopenEditor(sender, typeId);
+        return true;
+    }
+
+    private @NotNull Dialog buildEditor(final @NotNull DropType dropType) {
+        return Dialog.create(builder -> builder.empty()
+                .base(DialogBase.builder(Component.text("Edit type: " + dropType.getId()))
+                        .body(List.of(
+                                DialogBody.plainMessage(Component.text("Display: " + dropType.getDisplayName() + " | Type: " + dropType.getType()), 320),
+                                DialogBody.plainMessage(Component.text("Allowed types: " + plugin.getDropTypeManager().getDefaultTypes().stream().map(DropType::getId).toList()), 320)
+                        ))
+                        .inputs(List.of(
+                                DialogInput.text(DISPLAY_NAME_KEY, Component.text("Display Name")).initial(dropType.getDisplayName()).maxLength(128).width(320).build(),
+                                DialogInput.text(TYPE_KEY, Component.text("Type")).initial(dropType.getType()).maxLength(32).width(320).build()
+                        ))
+                        .canCloseWithEscape(true)
+                        .build())
+                .type(DialogType.confirmation(
+                        ActionButton.create(
+                                Component.text("Save"),
+                                Component.text("Apply these type edits"),
+                                120,
+                                DialogAction.customClick((response, audience) -> {
+                                    if (audience instanceof Player player) {
+                                        applyEdits(player, dropType.getId(), textValue(response.getText(DISPLAY_NAME_KEY)), textValue(response.getText(TYPE_KEY)));
+                                    }
+                                }, ClickCallback.Options.builder().uses(1).build())
+                        ),
+                        ActionButton.create(Component.text("Cancel"), Component.text("Discard these changes"), 120, null)
+                )));
+    }
+
+    private void reopenEditor(final @NotNull CommandSender sender, final @NotNull String typeId) {
+        if (sender instanceof Player player) {
+            player.showDialog(buildEditor(plugin.getDropTypeManager().getType(typeId)));
+        }
+    }
+
+    private @NotNull String textValue(final String input) {
+        return input == null ? "" : input.trim();
+    }
+}

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/edit/UpgradeEditService.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/commands/edit/UpgradeEditService.java
@@ -1,0 +1,111 @@
+package net.tinetwork.tradingcards.tradingcardsplugin.commands.edit;
+
+import io.papermc.paper.dialog.Dialog;
+import io.papermc.paper.registry.data.dialog.ActionButton;
+import io.papermc.paper.registry.data.dialog.DialogBase;
+import io.papermc.paper.registry.data.dialog.action.DialogAction;
+import io.papermc.paper.registry.data.dialog.body.DialogBody;
+import io.papermc.paper.registry.data.dialog.input.DialogInput;
+import io.papermc.paper.registry.data.dialog.type.DialogType;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickCallback;
+import net.tinetwork.tradingcards.api.model.Upgrade;
+import net.tinetwork.tradingcards.api.model.pack.PackEntry;
+import net.tinetwork.tradingcards.tradingcardsplugin.TradingCards;
+import net.tinetwork.tradingcards.tradingcardsplugin.messages.internal.InternalMessages;
+import net.tinetwork.tradingcards.tradingcardsplugin.utils.ChatUtil;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public final class UpgradeEditService {
+    private static final String REQUIRED_KEY = "required";
+    private static final String RESULT_KEY = "result";
+
+    private final TradingCards plugin;
+
+    public UpgradeEditService(final @NotNull TradingCards plugin) {
+        this.plugin = plugin;
+    }
+
+    public void openEditor(final @NotNull Player player, final @NotNull String upgradeId) {
+        player.showDialog(buildEditor(plugin.getUpgradeManager().getUpgrade(upgradeId)));
+    }
+
+    public boolean applyEdits(final @NotNull CommandSender sender, final @NotNull String upgradeId, final @NotNull String requiredInput, final @NotNull String resultInput) {
+        final PackEntry required = parseEntry(sender, requiredInput, "required");
+        if (required == null) {
+            return false;
+        }
+        final PackEntry result = parseEntry(sender, resultInput, "result");
+        if (result == null) {
+            return false;
+        }
+
+        plugin.getStorage().editUpgrade(upgradeId, required, result);
+        plugin.getUpgradeManager().getCache().refresh(upgradeId);
+        ChatUtil.sendPrefixedMessage(sender, "&7Updated &bupgrade &7for &b%s".formatted(upgradeId));
+        reopenEditor(sender, upgradeId);
+        return true;
+    }
+
+    private @NotNull Dialog buildEditor(final @NotNull Upgrade upgrade) {
+        return Dialog.create(builder -> builder.empty()
+                .base(DialogBase.builder(Component.text("Edit upgrade: " + upgrade.id()))
+                        .body(List.of(
+                                DialogBody.plainMessage(Component.text("Required: " + upgrade.required()), 340),
+                                DialogBody.plainMessage(Component.text("Result: " + upgrade.result()), 340),
+                                DialogBody.plainMessage(Component.text("Format: rarity:amount:series"), 340)
+                        ))
+                        .inputs(List.of(
+                                DialogInput.text(REQUIRED_KEY, Component.text("Required")).initial(upgrade.required().toString()).maxLength(128).width(340).build(),
+                                DialogInput.text(RESULT_KEY, Component.text("Result")).initial(upgrade.result().toString()).maxLength(128).width(340).build()
+                        ))
+                        .canCloseWithEscape(true)
+                        .build())
+                .type(DialogType.confirmation(
+                        ActionButton.create(
+                                Component.text("Save"),
+                                Component.text("Apply these upgrade edits"),
+                                120,
+                                DialogAction.customClick((response, audience) -> {
+                                    if (audience instanceof Player player) {
+                                        applyEdits(player, upgrade.id(), textValue(response.getText(REQUIRED_KEY)), textValue(response.getText(RESULT_KEY)));
+                                    }
+                                }, ClickCallback.Options.builder().uses(1).build())
+                        ),
+                        ActionButton.create(Component.text("Cancel"), Component.text("Discard these changes"), 120, null)
+                )));
+    }
+
+    private PackEntry parseEntry(final @NotNull CommandSender sender, final @NotNull String input, final @NotNull String fieldName) {
+        try {
+            final PackEntry entry = PackEntry.fromString(input);
+            if (!plugin.getRarityManager().containsRarity(entry.getRarityId())) {
+                ChatUtil.sendPrefixedMessage(sender, InternalMessages.NO_RARITY.formatted(entry.getRarityId()));
+                return null;
+            }
+            final String seriesId = entry.seriesId();
+            if (seriesId != null && !plugin.getSeriesManager().containsSeries(seriesId)) {
+                ChatUtil.sendPrefixedMessage(sender, InternalMessages.NO_SERIES.formatted(seriesId));
+                return null;
+            }
+            return entry;
+        } catch (RuntimeException ignored) {
+            ChatUtil.sendPrefixedMessage(sender, "&4Invalid %s entry. Expected format: &brarity:amount:series".formatted(fieldName));
+            return null;
+        }
+    }
+
+    private void reopenEditor(final @NotNull CommandSender sender, final @NotNull String upgradeId) {
+        if (sender instanceof Player player) {
+            player.showDialog(buildEditor(plugin.getUpgradeManager().getUpgrade(upgradeId)));
+        }
+    }
+
+    private @NotNull String textValue(final String input) {
+        return input == null ? "" : input.trim();
+    }
+}

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/Storage.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/Storage.java
@@ -184,6 +184,7 @@ public interface Storage<T extends Card<T>> {
     void editUpgradeRequired(final String upgradeId, final PackEntry required);
 
     void editUpgradeResult(final String upgradeId, final PackEntry result);
+    void editUpgrade(final String upgradeId, final PackEntry required, final PackEntry result);
 
     void deleteUpgrade(final String upgradeId);
 

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/Storage.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/Storage.java
@@ -206,6 +206,7 @@ public interface Storage<T extends Card<T>> {
     void editCardBuyPrice(final String rarityId,final String cardId, final String seriesId,final double value);
     void editCardHasShiny(final String rarityId,final String cardId, final String seriesId,final boolean value);
     void editCardCurrencyId(final String rarityId,final String cardId, final String seriesId, final String value);
+    void editCard(final String rarityId, final String cardId, final String seriesId, final String displayName, final Series targetSeries, final DropType type, final String info, final int customModelData, final double buyPrice, final double sellPrice, final boolean hasShiny, final String currencyId);
     // Edit Rarity
     void editRarityBuyPrice(final String rarityId, final double buyPrice);
     void editRarityAddReward(final String rarityId, final String reward);

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/Storage.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/Storage.java
@@ -214,16 +214,19 @@ public interface Storage<T extends Card<T>> {
     void editRarityRemoveAllRewards(final String rarityId);
     void editRarityRemoveReward(final String rarityId, final int rewardNumber);
     void editRarityCustomOrder(final String rarityId, final int customOrder);
+    void editRarity(final String rarityId, final String displayName, final String defaultColor, final double buyPrice, final double sellPrice, final String currencyId, final List<String> rewards);
     int getRarityCustomOrder(final String rarityId);
     // Edit Series
     void editSeriesDisplayName(final String seriesId, final String displayName);
     void editSeriesColors(final String seriesId, final ColorSeries colors);
     void editSeriesMode(final String seriesId, final Mode mode);
+    void editSeries(final String seriesId, final String displayName, final Mode mode, final ColorSeries colors);
     // Edit Series Colors
     void editColorSeries(final String seriesId, final ColorSeries colors);
     // Edit Type
     void editCustomTypeDisplayName(final String typeId, final String displayName);
     void editCustomTypeType(final String typeId, final String type); //It has to be a default type.
+    void editCustomType(final String typeId, final String displayName, final String type);
     // Edit Pack
     void editPackDisplayName(final String packId, final String displayName);
     void editPackContents(final String packId, final int lineNumber, final PackEntry packEntry);
@@ -236,6 +239,8 @@ public interface Storage<T extends Card<T>> {
     void editPackPermission(final String packId, final String permission);
     void editPackPrice(final String packId,final double price);
     void editPackCurrencyId(final String packId, final String currencyId);
+    void editPack(final String packId, final String displayName, final double price, final String permission, final String currencyId);
+    void editPack(final String packId, final String displayName, final double price, final String permission, final String currencyId, final List<PackEntry> contents, final List<PackEntry> tradeCards);
 
     /**
      * @return The total amount of cards.

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/local/CardsConfig.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/local/CardsConfig.java
@@ -64,4 +64,13 @@ public class CardsConfig {
     public Map<String,SimpleCardsConfig> getCardConfigs() {
         return cardConfigs;
     }
+
+    public SimpleCardsConfig getCardConfig(final String rarityId, final String cardId, final String seriesId) {
+        for (final SimpleCardsConfig config : cardConfigs.values()) {
+            if (config.containsCard(rarityId, cardId, seriesId)) {
+                return config;
+            }
+        }
+        return null;
+    }
 }

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/local/CustomTypesConfig.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/local/CustomTypesConfig.java
@@ -95,6 +95,16 @@ public class CustomTypesConfig extends YamlConfigurateFile<TradingCards> {
         }
     }
 
+    public void saveCustomType(final @NotNull String typeId, final @NotNull DropType dropType) {
+        try {
+            rootNode.node(typeId).set(dropType);
+            loader.save(rootNode);
+            reloadConfig();
+        } catch (ConfigurateException e) {
+            Util.logSevereException(e);
+        }
+    }
+
     public static class DropTypeSerializer implements TypeSerializer<DropType> {
         public static final DropTypeSerializer INSTANCE = new DropTypeSerializer();
         public static final Class<DropType> TYPE = DropType.class;

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/local/PacksConfig.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/local/PacksConfig.java
@@ -53,24 +53,40 @@ public class PacksConfig extends YamlConfigurateFile<TradingCards> {
     }
 
     public void editContents(final String packId, final int lineNumber, final PackEntry packEntry) {
-        ConfigurationNode packNode = rootNode.node(packId);
         try {
             Pack pack = getPack(packId);
-            pack.getPackEntryList().set(lineNumber,packEntry);
-            packNode.set(pack);
-            loader.save(rootNode);
+            List<PackEntry> entries = pack.getPackEntryList();
+            if (packEntry == null) {
+                if (lineNumber < 0 || lineNumber >= entries.size()) {
+                    return;
+                }
+                entries.remove(lineNumber);
+            } else if (lineNumber < entries.size()) {
+                entries.set(lineNumber, packEntry);
+            } else {
+                entries.add(packEntry);
+            }
+            savePack(pack);
         } catch (ConfigurateException e) {
             Util.logSevereException(e);
         }
     }
 
     public void editTradeCards(final String packId, final int lineNumber, final PackEntry packEntry) {
-        ConfigurationNode packNode = rootNode.node(packId);
         try {
             Pack pack = getPack(packId);
-            pack.getTradeCards().set(lineNumber,packEntry);
-            packNode.set(pack);
-            loader.save(rootNode);
+            List<PackEntry> entries = pack.getTradeCards();
+            if (packEntry == null) {
+                if (lineNumber < 0 || lineNumber >= entries.size()) {
+                    return;
+                }
+                entries.remove(lineNumber);
+            } else if (lineNumber < entries.size()) {
+                entries.set(lineNumber, packEntry);
+            } else {
+                entries.add(packEntry);
+            }
+            savePack(pack);
         } catch (ConfigurateException e) {
             Util.logSevereException(e);
         }
@@ -105,6 +121,16 @@ public class PacksConfig extends YamlConfigurateFile<TradingCards> {
         try {
             Pack pack = getPack(packId);
             pack.setCurrencyId(currencyId);
+            packNode.set(pack);
+            loader.save(rootNode);
+        } catch (ConfigurateException e) {
+            Util.logSevereException(e);
+        }
+    }
+
+    public void savePack(final Pack pack) {
+        ConfigurationNode packNode = rootNode.node(pack.getId());
+        try {
             packNode.set(pack);
             loader.save(rootNode);
         } catch (ConfigurateException e) {
@@ -198,9 +224,12 @@ public class PacksConfig extends YamlConfigurateFile<TradingCards> {
                 return;
             }
 
-            target.node(CONTENT).set(pack.getPackEntryList());
+            target.node(DISPLAY_NAME).set(pack.getDisplayName());
+            target.node(CONTENT).set(pack.getPackEntryList().stream().map(PackEntry::toString).toList());
             target.node(PRICE).set(pack.getBuyPrice());
+            target.node(CURRENCY_ID).set(pack.getCurrencyId());
             target.node(PERMISSION).set(pack.getPermission());
+            target.node(TRADE).set(pack.getTradeCards().stream().map(PackEntry::toString).toList());
         }
     }
 

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/local/RaritiesConfig.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/local/RaritiesConfig.java
@@ -174,6 +174,16 @@ public class RaritiesConfig extends RarityConfigurate{
         }
     }
 
+    public void saveRarity(final @NotNull String rarityId, final @NotNull Rarity rarity) {
+        try {
+            raritiesNode.node(rarityId).set(rarity);
+            loader.save(rootNode);
+            reloadConfig();
+        } catch (ConfigurateException e) {
+            Util.logSevereException(e);
+        }
+    }
+
     public static final class RaritySerializer implements TypeSerializer<Rarity> {
         public static final RaritySerializer INSTANCE = new RaritySerializer();
         public static final Class<Rarity> TYPE = Rarity.class;
@@ -229,6 +239,7 @@ public class RaritiesConfig extends RarityConfigurate{
             target.node(REWARDS).set(rarity.getRewards());
             target.node(BUY_PRICE).set(rarity.getBuyPrice());
             target.node(SELL_PRICE).set(rarity.getSellPrice());
+            target.node(CURRENCY_ID).set(rarity.getCurrencyId());
         }
     }
 

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/local/SeriesConfig.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/local/SeriesConfig.java
@@ -108,6 +108,16 @@ public class SeriesConfig extends SeriesConfigurate {
             Util.logSevereException(e);
         }
     }
+
+    public void saveSeries(final @NotNull String seriesId, final @NotNull Series series) {
+        try {
+            rootNode.node(seriesId).set(series);
+            loader.save(rootNode);
+            reloadConfig();
+        } catch (ConfigurateException e) {
+            Util.logSevereException(e);
+        }
+    }
     
     @Override
     protected void builderOptions(TypeSerializerCollection.Builder builder) {

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/local/SimpleCardsConfig.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/local/SimpleCardsConfig.java
@@ -306,7 +306,7 @@ public class SimpleCardsConfig extends YamlConfigurateFile<TradingCards> {
             
             target.node(DISPLAY_NAME).set(card.getDisplayName());
             target.node(SERIES).set(card.getSeries());
-            target.node(TYPE).set(card.getType());
+            target.node(TYPE).set(card.getType().getId());
             target.node(HAS_SHINY).set(card.hasShiny());
             target.node(INFO).set(card.getInfo());
             target.node(ABOUT).set(card.getAbout());

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/local/SimpleCardsConfig.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/local/SimpleCardsConfig.java
@@ -79,6 +79,26 @@ public class SimpleCardsConfig extends YamlConfigurateFile<TradingCards> {
             Util.logSevereException(e);
         }
     }
+
+    public boolean containsCard(final String rarityId, final String cardId, final String seriesId) {
+        final ConfigurationNode cardNode = cardsNode.node(rarityId, cardId);
+        if (cardNode.virtual()) {
+            return false;
+        }
+
+        final String storedSeriesId = cardNode.node("series").getString();
+        return seriesId.equals(storedSeriesId);
+    }
+
+    public void saveCard(final String rarityId, final String cardId, final TradingCard card) {
+        try {
+            cardsNode.node(rarityId, cardId).set(card);
+            loader.save(rootNode);
+            reloadConfig();
+        } catch (ConfigurateException e) {
+            Util.logSevereException(e);
+        }
+    }
     
     public void editDisplayName(final String rarityId, final String cardId, final String seriesId, final String displayName) {
         new EditCardConfig<String>(rootNode, cardsNode, loader, this) {

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/local/UpgradesConfig.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/local/UpgradesConfig.java
@@ -94,6 +94,16 @@ public class UpgradesConfig extends YamlConfigurateFile<TradingCards> {
         }
     }
 
+    public void saveUpgrade(final String upgradeId, final Upgrade upgrade) {
+        ConfigurationNode upgradeNode = rootNode.node(upgradeId);
+        try {
+            upgradeNode.set(upgrade);
+            loader.save(rootNode);
+        } catch (ConfigurateException e) {
+            Util.logSevereException(e);
+        }
+    }
+
     public void deleteUpgrade(final String upgradeId) {
         ConfigurationNode upgradeNode = rootNode.node(upgradeId);
         try {

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/local/YamlStorage.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/local/YamlStorage.java
@@ -504,6 +504,18 @@ public class YamlStorage implements Storage<TradingCard> {
     }
 
     @Override
+    public void editRarity(final String rarityId, final String displayName, final String defaultColor, final double buyPrice, final double sellPrice, final String currencyId, final List<String> rewards) {
+        final Rarity rarity = getRarityById(rarityId);
+        rarity.setDisplayName(displayName);
+        rarity.setDefaultColor(defaultColor);
+        rarity.setBuyPrice(buyPrice);
+        rarity.setSellPrice(sellPrice);
+        rarity.setCurrencyId(currencyId);
+        rarity.setRewards(new ArrayList<>(rewards));
+        raritiesConfig.saveRarity(rarityId, rarity);
+    }
+
+    @Override
     public void editSeriesDisplayName(final String seriesId, final String displayName) {
         seriesConfig.editDisplayName(seriesId, displayName);
     }
@@ -516,6 +528,15 @@ public class YamlStorage implements Storage<TradingCard> {
     @Override
     public void editSeriesMode(final String seriesId, final Mode mode) {
         seriesConfig.editMode(seriesId, mode);
+    }
+
+    @Override
+    public void editSeries(final String seriesId, final String displayName, final Mode mode, final ColorSeries colors) {
+        final Series series = getSeries(seriesId);
+        series.setDisplayName(displayName);
+        series.setMode(mode);
+        series.setColorSeries(colors);
+        seriesConfig.saveSeries(seriesId, series);
     }
 
     @Override
@@ -534,6 +555,14 @@ public class YamlStorage implements Storage<TradingCard> {
     }
 
     @Override
+    public void editCustomType(final String typeId, final String displayName, final String type) {
+        final DropType dropType = getCustomType(typeId);
+        dropType.setDisplayName(displayName);
+        dropType.setType(type);
+        customTypesConfig.saveCustomType(typeId, dropType);
+    }
+
+    @Override
     public void editPackDisplayName(final String packId, final String displayName) {
         packsConfig.editDisplayName(packId, displayName);
     }
@@ -546,7 +575,7 @@ public class YamlStorage implements Storage<TradingCard> {
     @Override
     public void editPackContentsAdd(final String packId, final PackEntry packEntry) {
         List<PackEntry> packEntries = getPack(packId).getPackEntryList();
-        int lineNumber = (packEntries == null) ? 0 : packEntries.size() - 1;
+        int lineNumber = (packEntries == null) ? 0 : packEntries.size();
         packsConfig.editContents(packId, lineNumber, packEntry);
     }
 
@@ -563,7 +592,7 @@ public class YamlStorage implements Storage<TradingCard> {
     @Override
     public void editPackTradeCardsAdd(final String packId, final PackEntry packEntry) {
         List<PackEntry> packEntries = getPack(packId).getTradeCards();
-        int lineNumber = (packEntries == null) ? 0 : packEntries.size() - 1;
+        int lineNumber = (packEntries == null) ? 0 : packEntries.size();
         packsConfig.editTradeCards(packId, lineNumber, packEntry);
     }
 
@@ -585,6 +614,30 @@ public class YamlStorage implements Storage<TradingCard> {
     @Override
     public void editPackCurrencyId(final String packId, final String currencyId) {
         packsConfig.editCurrencyId(packId, currencyId);
+    }
+
+    @Override
+    public void editPack(final String packId, final String displayName, final double price, final String permission, final String currencyId) {
+        final Pack pack = getPack(packId);
+        pack.setDisplayName(displayName);
+        pack.setBuyPrice(price);
+        pack.setPermission(permission);
+        pack.setCurrencyId(currencyId);
+        packsConfig.savePack(pack);
+    }
+
+    @Override
+    public void editPack(final String packId, final String displayName, final double price, final String permission, final String currencyId, final List<PackEntry> contents, final List<PackEntry> tradeCards) {
+        final Pack pack = new Pack(
+                packId,
+                new ArrayList<>(contents),
+                displayName,
+                price,
+                currencyId,
+                permission,
+                new ArrayList<>(tradeCards)
+        );
+        packsConfig.savePack(pack);
     }
 
     @Override

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/local/YamlStorage.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/local/YamlStorage.java
@@ -178,6 +178,7 @@ public class YamlStorage implements Storage<TradingCard> {
         this.customTypesConfig.reloadConfig();
         this.cardsConfig.initValues();
         this.packsConfig.reloadConfig();
+        refreshCardIndexes();
     }
 
     @Override
@@ -409,58 +410,138 @@ public class YamlStorage implements Storage<TradingCard> {
         return plugin.getStorageConfig().getDefaultCardsFile();
     }
 
+    private @Nullable SimpleCardsConfig getCardConfigForEdit(final String rarityId, final String cardId, final String seriesId) {
+        final SimpleCardsConfig config = cardsConfig.getCardConfig(rarityId, cardId, seriesId);
+        if (config != null) {
+            return config;
+        }
+        return cardsConfig.getCardConfigs().get(getDefaultEditCardFile());
+    }
+
+    private void refreshCardIndexes() {
+        this.cards.clear();
+        this.activeCards.clear();
+        this.rarityCardList.clear();
+        this.seriesCardList.clear();
+        this.activeSeries.clear();
+        loadCards();
+        loadActiveSeries();
+        loadActiveCards();
+        loadRarityCards();
+        loadSeriesCards();
+        loadRaritySeriesCardList();
+    }
+
     @Override
     public void editCardDisplayName(final String rarityId, final String cardId, final String seriesId, final String displayName) {
-        SimpleCardsConfig simpleCardsConfig = cardsConfig.getCardConfigs().get(getDefaultEditCardFile());
+        final SimpleCardsConfig simpleCardsConfig = getCardConfigForEdit(rarityId, cardId, seriesId);
+        if (simpleCardsConfig == null) {
+            return;
+        }
         simpleCardsConfig.editDisplayName(rarityId, cardId, seriesId, displayName);
+        refreshCardIndexes();
     }
 
     @Override
     public void editCardSeries(final String rarityId, final String cardId, final String seriesId, final Series value) {
-        SimpleCardsConfig simpleCardsConfig = cardsConfig.getCardConfigs().get(getDefaultEditCardFile());
+        final SimpleCardsConfig simpleCardsConfig = getCardConfigForEdit(rarityId, cardId, seriesId);
+        if (simpleCardsConfig == null) {
+            return;
+        }
         simpleCardsConfig.editSeries(rarityId, cardId, seriesId, value);
+        refreshCardIndexes();
     }
 
     @Override
     public void editCardSellPrice(final String rarityId, final String cardId, final String seriesId, final double value) {
-        SimpleCardsConfig simpleCardsConfig = cardsConfig.getCardConfigs().get(getDefaultEditCardFile());
+        final SimpleCardsConfig simpleCardsConfig = getCardConfigForEdit(rarityId, cardId, seriesId);
+        if (simpleCardsConfig == null) {
+            return;
+        }
         simpleCardsConfig.editSellPrice(rarityId, cardId, seriesId, value);
+        refreshCardIndexes();
     }
 
     @Override
     public void editCardType(final String rarityId, final String cardId, final String seriesId, final DropType value) {
-        SimpleCardsConfig simpleCardsConfig = cardsConfig.getCardConfigs().get(getDefaultEditCardFile());
+        final SimpleCardsConfig simpleCardsConfig = getCardConfigForEdit(rarityId, cardId, seriesId);
+        if (simpleCardsConfig == null) {
+            return;
+        }
         simpleCardsConfig.editType(rarityId, cardId, seriesId, value);
+        refreshCardIndexes();
     }
 
     @Override
     public void editCardInfo(final String rarityId, final String cardId, final String seriesId, final String value) {
-        SimpleCardsConfig simpleCardsConfig = cardsConfig.getCardConfigs().get(getDefaultEditCardFile());
+        final SimpleCardsConfig simpleCardsConfig = getCardConfigForEdit(rarityId, cardId, seriesId);
+        if (simpleCardsConfig == null) {
+            return;
+        }
         simpleCardsConfig.editInfo(rarityId, cardId, seriesId, value);
+        refreshCardIndexes();
     }
 
     @Override
     public void editCardCustomModelData(final String rarityId, final String cardId, final String seriesId, final int value) {
-        SimpleCardsConfig simpleCardsConfig = cardsConfig.getCardConfigs().get(getDefaultEditCardFile());
+        final SimpleCardsConfig simpleCardsConfig = getCardConfigForEdit(rarityId, cardId, seriesId);
+        if (simpleCardsConfig == null) {
+            return;
+        }
         simpleCardsConfig.editModelData(rarityId, cardId, seriesId, value);
+        refreshCardIndexes();
     }
 
     @Override
     public void editCardBuyPrice(final String rarityId, final String cardId, final String seriesId, final double value) {
-        SimpleCardsConfig simpleCardsConfig = cardsConfig.getCardConfigs().get(getDefaultEditCardFile());
+        final SimpleCardsConfig simpleCardsConfig = getCardConfigForEdit(rarityId, cardId, seriesId);
+        if (simpleCardsConfig == null) {
+            return;
+        }
         simpleCardsConfig.editBuyPrice(rarityId, cardId, seriesId, value);
+        refreshCardIndexes();
     }
 
     @Override
     public void editCardHasShiny(final String rarityId, final String cardId, final String seriesId, final boolean value) {
-        SimpleCardsConfig simpleCardsConfig = cardsConfig.getCardConfigs().get(getDefaultEditCardFile());
+        final SimpleCardsConfig simpleCardsConfig = getCardConfigForEdit(rarityId, cardId, seriesId);
+        if (simpleCardsConfig == null) {
+            return;
+        }
         simpleCardsConfig.editHasShiny(rarityId, cardId, seriesId, value);
+        refreshCardIndexes();
     }
 
     @Override
     public void editCardCurrencyId(final String rarityId, final String cardId, final String seriesId, final String value) {
-        SimpleCardsConfig simpleCardsConfig = cardsConfig.getCardConfigs().get(getDefaultEditCardFile());
+        final SimpleCardsConfig simpleCardsConfig = getCardConfigForEdit(rarityId, cardId, seriesId);
+        if (simpleCardsConfig == null) {
+            return;
+        }
         simpleCardsConfig.editCurrencyId(rarityId, cardId, seriesId, value);
+        refreshCardIndexes();
+    }
+
+    @Override
+    public void editCard(final String rarityId, final String cardId, final String seriesId, final String displayName, final Series targetSeries, final DropType type, final String info, final int customModelData, final double buyPrice, final double sellPrice, final boolean hasShiny, final String currencyId) {
+        final SimpleCardsConfig simpleCardsConfig = getCardConfigForEdit(rarityId, cardId, seriesId);
+        if (simpleCardsConfig == null) {
+            return;
+        }
+
+        final TradingCard existingCard = getCard(cardId, rarityId, seriesId).get();
+        final TradingCard updatedCard = new TradingCard(existingCard);
+        updatedCard.displayName(displayName)
+                .series(targetSeries)
+                .type(type)
+                .info(info)
+                .customModelNbt(customModelData)
+                .buyPrice(buyPrice)
+                .sellPrice(sellPrice)
+                .hasShiny(hasShiny)
+                .currencyId(currencyId);
+        simpleCardsConfig.saveCard(rarityId, cardId, updatedCard);
+        refreshCardIndexes();
     }
 
     @Override

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/local/YamlStorage.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/local/YamlStorage.java
@@ -691,6 +691,11 @@ public class YamlStorage implements Storage<TradingCard> {
     }
 
     @Override
+    public void editUpgrade(final String upgradeId, final PackEntry required, final PackEntry result) {
+        upgradesConfig.saveUpgrade(upgradeId, new Upgrade(upgradeId, required, result));
+    }
+
+    @Override
     public void deleteUpgrade(final String upgradeId) {
         upgradesConfig.deleteUpgrade(upgradeId);
     }

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/remote/SqlStorage.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/remote/SqlStorage.java
@@ -892,6 +892,7 @@ public class SqlStorage implements Storage<TradingCard> {
         final boolean hasShiny = JooqRecordUtil.getOrDefault(recordResult.get(Cards.CARDS.HAS_SHINY), false);
         final Series series = getSeries(recordResult.getValue(Cards.CARDS.SERIES_ID));
         final String info = recordResult.getValue(Cards.CARDS.INFO);
+        final String currencyId = JooqRecordUtil.getOrDefault(recordResult.getValue(Cards.CARDS.CURRENCY_ID), plugin.getEconomyWrapper().getPrimaryCurrencyId());
         final int customModelData = JooqRecordUtil.getOrDefault(recordResult.getValue(Cards.CARDS.CUSTOM_MODEL_DATA), 0);
         final double buyPrice = JooqRecordUtil.getOrDefault(recordResult.getValue(Cards.CARDS.BUY_PRICE), 0D);
         final double sellPrice = JooqRecordUtil.getOrDefault(recordResult.getValue(Cards.CARDS.SELL_PRICE), 0D);
@@ -905,7 +906,8 @@ public class SqlStorage implements Storage<TradingCard> {
                 .info(info)
                 .customModelNbt(customModelData)
                 .buyPrice(buyPrice)
-                .sellPrice(sellPrice);
+                .sellPrice(sellPrice)
+                .currencyId(currencyId);
         return card;
     }
 
@@ -1781,6 +1783,29 @@ public class SqlStorage implements Storage<TradingCard> {
                 dslContext.update(CustomTypes.CUSTOM_TYPES)
                         .set(CustomTypes.CUSTOM_TYPES.DROP_TYPE, CustomTypesDropType.lookupLiteral(defaultTypeId))
                         .where(CustomTypes.CUSTOM_TYPES.TYPE_ID.eq(customTypeId)).execute();
+            }
+        }.executeUpdate();
+    }
+
+    @Override
+    public void editCard(final String rarityId, final String cardId, final String seriesId, final String displayName, final Series targetSeries, final DropType type, final String info, final int customModelData, final double buyPrice, final double sellPrice, final boolean hasShiny, final String currencyId) {
+        new ExecuteUpdate(connectionFactory, jooqSettings) {
+            @Override
+            protected void onRunUpdate(final DSLContext dslContext) {
+                dslContext.update(Cards.CARDS)
+                        .set(Cards.CARDS.DISPLAY_NAME, displayName)
+                        .set(Cards.CARDS.SERIES_ID, targetSeries.getId())
+                        .set(Cards.CARDS.TYPE_ID, type.getId())
+                        .set(Cards.CARDS.INFO, info)
+                        .set(Cards.CARDS.CUSTOM_MODEL_DATA, customModelData)
+                        .set(Cards.CARDS.BUY_PRICE, buyPrice)
+                        .set(Cards.CARDS.SELL_PRICE, sellPrice)
+                        .set(Cards.CARDS.HAS_SHINY, hasShiny)
+                        .set(Cards.CARDS.CURRENCY_ID, currencyId)
+                        .where(Cards.CARDS.RARITY_ID.eq(rarityId))
+                        .and(Cards.CARDS.CARD_ID.eq(cardId))
+                        .and(Cards.CARDS.SERIES_ID.eq(seriesId))
+                        .execute();
             }
         }.executeUpdate();
     }

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/remote/SqlStorage.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/remote/SqlStorage.java
@@ -1824,7 +1824,8 @@ public class SqlStorage implements Storage<TradingCard> {
                         .set(PacksContent.PACKS_CONTENT.SERIES_ID, packEntry.seriesId())
                         .set(PacksContent.PACKS_CONTENT.RARITY_ID, packEntry.getRarityId())
                         .set(PacksContent.PACKS_CONTENT.CARD_AMOUNT, String.valueOf(packEntry.getAmount()))
-                        .where(PacksContent.PACKS_CONTENT.LINE_NUMBER.eq(lineNumber))
+                        .where(PacksContent.PACKS_CONTENT.PACK_ID.eq(packId)
+                                .and(PacksContent.PACKS_CONTENT.LINE_NUMBER.eq(lineNumber)))
                         .execute();
             }
         }.executeUpdate();
@@ -1884,7 +1885,9 @@ public class SqlStorage implements Storage<TradingCard> {
                         .set(PacksTrade.PACKS_TRADE.SERIES_ID, packEntry.seriesId())
                         .set(PacksTrade.PACKS_TRADE.RARITY_ID, packEntry.getRarityId())
                         .set(PacksTrade.PACKS_TRADE.CARD_AMOUNT, String.valueOf(packEntry.getAmount()))
-                        .where(PacksTrade.PACKS_TRADE.LINE_NUMBER.eq(lineNumber)).execute();
+                        .where(PacksTrade.PACKS_TRADE.PACK_ID.eq(packId)
+                                .and(PacksTrade.PACKS_TRADE.LINE_NUMBER.eq(lineNumber)))
+                        .execute();
             }
         }.executeUpdate();
     }
@@ -1953,6 +1956,131 @@ public class SqlStorage implements Storage<TradingCard> {
                         .set(Packs.PACKS.CURRENCY_ID, currencyId)
                         .where(Packs.PACKS.PACK_ID.eq(packId))
                         .execute();
+            }
+        }.executeUpdate();
+    }
+
+    @Override
+    public void editCustomType(final String typeId, final String displayName, final String type) {
+        new ExecuteUpdate(connectionFactory, jooqSettings) {
+            @Override
+            protected void onRunUpdate(final DSLContext dslContext) {
+                dslContext.update(CustomTypes.CUSTOM_TYPES)
+                        .set(CustomTypes.CUSTOM_TYPES.DISPLAY_NAME, displayName)
+                        .set(CustomTypes.CUSTOM_TYPES.DROP_TYPE, CustomTypesDropType.lookupLiteral(type))
+                        .where(CustomTypes.CUSTOM_TYPES.TYPE_ID.eq(typeId))
+                        .execute();
+            }
+        }.executeUpdate();
+    }
+
+    @Override
+    public void editSeries(final String seriesId, final String displayName, final Mode mode, final ColorSeries colors) {
+        new ExecuteUpdate(connectionFactory, jooqSettings) {
+            @Override
+            protected void onRunUpdate(final DSLContext dslContext) {
+                dslContext.update(net.tinetwork.tradingcards.tradingcardsplugin.storage.impl.remote.generated.tables.Series.SERIES)
+                        .set(net.tinetwork.tradingcards.tradingcardsplugin.storage.impl.remote.generated.tables.Series.SERIES.DISPLAY_NAME, displayName)
+                        .set(net.tinetwork.tradingcards.tradingcardsplugin.storage.impl.remote.generated.tables.Series.SERIES.SERIES_MODE, SeriesSeriesMode.lookupLiteral(mode.name()))
+                        .where(net.tinetwork.tradingcards.tradingcardsplugin.storage.impl.remote.generated.tables.Series.SERIES.SERIES_ID.eq(seriesId))
+                        .execute();
+
+                dslContext.update(SeriesColors.SERIES_COLORS)
+                        .set(SeriesColors.SERIES_COLORS.SERIES, colors.getSeries())
+                        .set(SeriesColors.SERIES_COLORS.ABOUT, colors.getAbout())
+                        .set(SeriesColors.SERIES_COLORS.INFO, colors.getInfo())
+                        .set(SeriesColors.SERIES_COLORS.RARITY, colors.getRarity())
+                        .set(SeriesColors.SERIES_COLORS.TYPE, colors.getType())
+                        .where(SeriesColors.SERIES_COLORS.SERIES_ID.eq(seriesId))
+                        .execute();
+            }
+        }.executeUpdate();
+    }
+
+    @Override
+    public void editRarity(final String rarityId, final String displayName, final String defaultColor, final double buyPrice, final double sellPrice, final String currencyId, final List<String> rewards) {
+        new ExecuteUpdate(connectionFactory, jooqSettings) {
+            @Override
+            protected void onRunUpdate(final DSLContext dslContext) {
+                dslContext.update(Rarities.RARITIES)
+                        .set(Rarities.RARITIES.DISPLAY_NAME, displayName)
+                        .set(Rarities.RARITIES.DEFAULT_COLOR, defaultColor)
+                        .set(Rarities.RARITIES.BUY_PRICE, buyPrice)
+                        .set(Rarities.RARITIES.SELL_PRICE, sellPrice)
+                        .set(Rarities.RARITIES.CURRENCY_ID, currencyId)
+                        .where(Rarities.RARITIES.RARITY_ID.eq(rarityId))
+                        .execute();
+
+                dslContext.deleteFrom(Rewards.REWARDS)
+                        .where(Rewards.REWARDS.RARITY_ID.eq(rarityId))
+                        .execute();
+                for (int i = 0; i < rewards.size(); i++) {
+                    dslContext.insertInto(Rewards.REWARDS)
+                            .set(Rewards.REWARDS.RARITY_ID, rarityId)
+                            .set(Rewards.REWARDS.COMMAND, rewards.get(i))
+                            .set(Rewards.REWARDS.COMMAND_ORDER, i)
+                            .execute();
+                }
+            }
+        }.executeUpdate();
+    }
+
+    @Override
+    public void editPack(final String packId, final String displayName, final double price, final String permission, final String currencyId) {
+        new ExecuteUpdate(connectionFactory, jooqSettings) {
+            @Override
+            protected void onRunUpdate(final DSLContext dslContext) {
+                dslContext.update(Packs.PACKS)
+                        .set(Packs.PACKS.DISPLAY_NAME, displayName)
+                        .set(Packs.PACKS.BUY_PRICE, price)
+                        .set(Packs.PACKS.PERMISSION, permission)
+                        .set(Packs.PACKS.CURRENCY_ID, currencyId)
+                        .where(Packs.PACKS.PACK_ID.eq(packId))
+                        .execute();
+            }
+        }.executeUpdate();
+    }
+
+    @Override
+    public void editPack(final String packId, final String displayName, final double price, final String permission, final String currencyId, final List<PackEntry> contents, final List<PackEntry> tradeCards) {
+        new ExecuteUpdate(connectionFactory, jooqSettings) {
+            @Override
+            protected void onRunUpdate(final DSLContext dslContext) {
+                dslContext.update(Packs.PACKS)
+                        .set(Packs.PACKS.DISPLAY_NAME, displayName)
+                        .set(Packs.PACKS.BUY_PRICE, price)
+                        .set(Packs.PACKS.PERMISSION, permission)
+                        .set(Packs.PACKS.CURRENCY_ID, currencyId)
+                        .where(Packs.PACKS.PACK_ID.eq(packId))
+                        .execute();
+
+                dslContext.deleteFrom(PacksContent.PACKS_CONTENT)
+                        .where(PacksContent.PACKS_CONTENT.PACK_ID.eq(packId))
+                        .execute();
+                for (int i = 0; i < contents.size(); i++) {
+                    final PackEntry entry = contents.get(i);
+                    dslContext.insertInto(PacksContent.PACKS_CONTENT)
+                            .set(PacksContent.PACKS_CONTENT.PACK_ID, packId)
+                            .set(PacksContent.PACKS_CONTENT.LINE_NUMBER, i)
+                            .set(PacksContent.PACKS_CONTENT.SERIES_ID, entry.seriesId())
+                            .set(PacksContent.PACKS_CONTENT.RARITY_ID, entry.getRarityId())
+                            .set(PacksContent.PACKS_CONTENT.CARD_AMOUNT, String.valueOf(entry.getAmount()))
+                            .execute();
+                }
+
+                dslContext.deleteFrom(PacksTrade.PACKS_TRADE)
+                        .where(PacksTrade.PACKS_TRADE.PACK_ID.eq(packId))
+                        .execute();
+                for (int i = 0; i < tradeCards.size(); i++) {
+                    final PackEntry entry = tradeCards.get(i);
+                    dslContext.insertInto(PacksTrade.PACKS_TRADE)
+                            .set(PacksTrade.PACKS_TRADE.PACK_ID, packId)
+                            .set(PacksTrade.PACKS_TRADE.LINE_NUMBER, i)
+                            .set(PacksTrade.PACKS_TRADE.SERIES_ID, entry.seriesId())
+                            .set(PacksTrade.PACKS_TRADE.RARITY_ID, entry.getRarityId())
+                            .set(PacksTrade.PACKS_TRADE.CARD_AMOUNT, String.valueOf(entry.getAmount()))
+                            .execute();
+                }
             }
         }.executeUpdate();
     }

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/remote/SqlStorage.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/storage/impl/remote/SqlStorage.java
@@ -2288,6 +2288,28 @@ public class SqlStorage implements Storage<TradingCard> {
     }
 
     @Override
+    public void editUpgrade(final String upgradeId, final PackEntry required, final PackEntry result) {
+        new ExecuteUpdate(connectionFactory, jooqSettings) {
+            @Override
+            protected void onRunUpdate(final DSLContext dslContext) {
+                dslContext.update(UpgradesRequired.UPGRADES_REQUIRED
+                                .where(UpgradesRequired.UPGRADES_REQUIRED.UPGRADE_ID.eq(upgradeId)))
+                        .set(UpgradesRequired.UPGRADES_REQUIRED.RARITY_ID, required.rarityId())
+                        .set(UpgradesRequired.UPGRADES_REQUIRED.SERIES_ID, required.seriesId())
+                        .set(UpgradesRequired.UPGRADES_REQUIRED.AMOUNT, required.amount())
+                        .execute();
+
+                dslContext.update(UpgradesResult.UPGRADES_RESULT
+                                .where(UpgradesResult.UPGRADES_RESULT.UPGRADE_ID.eq(upgradeId)))
+                        .set(UpgradesResult.UPGRADES_RESULT.RARITY_ID, result.rarityId())
+                        .set(UpgradesResult.UPGRADES_RESULT.SERIES_ID, result.seriesId())
+                        .set(UpgradesResult.UPGRADES_RESULT.AMOUNT, result.amount())
+                        .execute();
+            }
+        }.executeUpdate();
+    }
+
+    @Override
     public List<Upgrade> getUpgrades() {
         return new ExecuteQuery<List<Upgrade>, Result<Record>>(connectionFactory, jooqSettings) {
             @Override

--- a/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/utils/ChatUtil.java
+++ b/tradingcards-plugin/src/main/java/net/tinetwork/tradingcards/tradingcardsplugin/utils/ChatUtil.java
@@ -51,6 +51,10 @@ public class ChatUtil {
         return LegacyComponentSerializer.builder().character(ALT_COLOR_CHAR).build().serialize(component);
     }
 
+    public static @NotNull Component component(final @Nullable String text) {
+        return LegacyComponentSerializer.builder().character(ALT_COLOR_CHAR).build().deserialize(text == null ? "" : text);
+    }
+
     @Contract("_ -> new")
     public static @NotNull String color(String text) {
         return com.github.sarhatabaot.kraken.core.chat.ChatUtil.color(text);


### PR DESCRIPTION
## Summary

This PR replaces the current admin edit flow for packs, rarities, series, custom types, upgrades, and cards with Paper dialog-based editors, while keeping the existing command argument flow as a fallback.

**The dialog editors now support:**
- Pack editing with split sections for details, contents, and trade
- Rarity editing with split sections for details and rewards
- Series, type, and upgrade editing
- Card editing with split sections for details, economy, and info
- Item previews for cards and packs
- Automatic reopen after successful saves so multiple edits can be chained without rerunning commands

On the backend, this also adds batched save paths and fixes a number of storage issues that became visible once edits started being submitted as grouped dialog updates.

---

## What Changed

### UI / Command Flow

Added player-only dialog entrypoints for:
- `/cards edit pack <packId>`
- `/cards edit rarity <rarityId>`
- `/cards edit series <seriesId>`
- `/cards edit type <typeId>`
- `/cards edit upgrade <upgradeId>`
- `/cards edit card <rarity> <series> <cardId>`

**Preserved** the existing command-based edit subcommands for console use, scripting, and fallback.

- Split larger editors into smaller focused dialogs instead of one oversized form
- Added read-only summaries to menu dialogs
- Added dedicated preview dialogs for item-backed editors:
  - Cards
  - Packs

### Card-Specific Improvements

- Added constrained inputs for card `series` and `type` using dialog option selectors
- Switched `has shiny` to a proper boolean dialog input
- Added card preview dialogs showing the resulting item, including shiny preview when applicable

### Storage / Backend

Added batch edit methods to storage for:
- Pack scalar and list updates
- Rarity updates
- Series updates
- Custom type updates
- Upgrade updates
- Card updates

**Fixes:**
- Fixed YAML pack serialization so all edited fields persist correctly
- Fixed pack content/trade append/delete behavior in YAML
- Fixed SQL pack content/trade updates to scope by `pack_id` and `line_number`
- Fixed card YAML writes to target the correct card config file instead of always using the default cards file
- Fixed card YAML serialization to persist drop type as its ID string instead of trying to serialize the full `DropType` object
- Added cache refresh handling for card series changes so the old and new card keys stay coherent

### Dialog Rendering

- Added legacy-string-to-Component conversion for dialog display text
- Dialogs now render configured `&`-style formatting instead of showing raw color codes

---

## How This Differs From Issue #498

Relative to the original issue draft for dialog-based editing, this PR goes further in a few ways:

- It does not stop at packs. It also implements dialogs for rarities, series, types, upgrades, and cards.
- It adds preview support for cards and packs, which was not part of the initial dialog migration scope.
- It includes backend/storage fixes that were not just "nice to have"; they were required to make batched dialog edits safe.
- It keeps the old command editing flow in place instead of fully replacing it.
- It tightens the card editor beyond the original draft by using constrained dialog inputs for valid values.

At the same time, it is narrower than a full "all editors fully visualized" interpretation of the issue:

- Only item-backed editors currently have true item previews.
- Rarity, series, type, and upgrade still use data-oriented dialogs rather than synthetic item previews.

---

## Testing

- `./gradlew :tradingcards-plugin:compileJava` passed throughout the work
- Dialog flows were tested incrementally during implementation
- Card serializer error on YAML save was reproduced and fixed as part of this PR

Closes #498 